### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A Search-Based Decoder for Quantum Error Correction.
 Tesseract is a Most Likely Error decoder designed for Low Density Parity Check (LDPC) quantum
 error-correcting codes. It applies pruning heuristics and manifold orientation techniques during a
 search over the error subsets to identify the most likely error configuration consistent with the
-observed syndrome. Tesseract archives significant speed improvements over traditional integer
+observed syndrome. Tesseract achieves significant speed improvements over traditional integer
 programming-based decoders while maintaining comparable accuracy at moderate physical error rates.
 
 We tested the Tesseract decoder for:


### PR DESCRIPTION
## Summary
- fix wording in README

## Testing
- `bazel test src:all` *(fails: could not download Bazel)*

------
https://chatgpt.com/codex/tasks/task_e_684215aa9a4883208786e11d4c9744f1