### PR TITLE
Fix Bazel build on Linux

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -27,7 +27,6 @@ OPT_COPTS = select({
     "//conditions:default": [
         "-Ofast",
         "-fno-fast-math",
-        "-flto",
         "-march=native",
     ],
     ":debug": ["-Og"],
@@ -42,7 +41,6 @@ OPT_LINKOPTS = select({
     "//conditions:default": [
         "-Ofast",
         "-fno-fast-math",
-        "-flto",
         "-march=native",
     ],
     ":debug": [],
@@ -141,6 +139,7 @@ cc_test(
 cc_test(
     name = "common_tests",
     srcs = ["common.test.cc"],
+    linkstatic = True,
     deps = [
         ":libcommon",
         "@gtest",


### PR DESCRIPTION
## Summary
- disable `-flto` which caused missing symbols when linking tests
- link `common_tests` statically so symbols resolve

## Testing
- `bazel build //src:common_tests`
- `bazel test //src:common_tests`
- `bazel build //...`
- `bazel test //...` *(failed: build interrupted after long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_684484f853a083208b865e8fb451518c