### PR TITLE
Fix dem_from_counts indexing for zero-probability errors

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -141,6 +141,8 @@ cc_test(
 cc_test(
     name = "common_tests",
     srcs = ["common.test.cc"],
+    copts = OPT_COPTS,
+    linkopts = OPT_LINKOPTS,
     deps = [
         ":libcommon",
         "@gtest",

--- a/src/common.cc
+++ b/src/common.cc
@@ -130,14 +130,14 @@ stim::DetectorErrorModel common::dem_from_counts(
         assert(false && "unreachable");
         break;
       case stim::DemInstructionType::DEM_ERROR: {
+        double est_probability =
+            double(error_counts.at(ei)) / double(num_shots);
         // Ignore zero-probability errors
         if (instruction.arg_data[0] > 0) {
-          double est_probability =
-              double(error_counts.at(ei)) / double(num_shots);
           out_dem.append_error_instruction(est_probability,
                                            instruction.target_data, /*tag=*/"");
-          ++ei;
         }
+        ++ei;
         break;
       }
       case stim::DemInstructionType::DEM_DETECTOR: {

--- a/src/common.cc
+++ b/src/common.cc
@@ -132,7 +132,7 @@ stim::DetectorErrorModel common::dem_from_counts(
       case stim::DemInstructionType::DEM_ERROR: {
         double est_probability =
             double(error_counts.at(ei)) / double(num_shots);
-        // Ignore zero-probability errors
+        // Ignore zero-probability errors but always advance the index
         if (instruction.arg_data[0] > 0) {
           out_dem.append_error_instruction(est_probability,
                                            instruction.target_data, /*tag=*/"");

--- a/src/common.test.cc
+++ b/src/common.test.cc
@@ -25,3 +25,55 @@ TEST(common, ErrorsStructFromDemInstruction) {
   EXPECT_EQ(ES.symptom.detectors, std::vector<int>{1});
   EXPECT_EQ(ES.symptom.observables, 0b01);
 }
+
+TEST(common, DemFromCountsHandlesZeroProbabilityErrors) {
+  stim::DetectorErrorModel dem(R"DEM(
+        error(0.1) D0
+        error(0) D1
+        error(0.2) D2
+        detector(0, 0, 0) D0
+        detector(0, 0, 0) D1
+        detector(0, 0, 0) D2
+      )DEM");
+
+  std::vector<size_t> counts{1, 7, 4};
+  size_t num_shots = 10;
+  stim::DetectorErrorModel out_dem =
+      common::dem_from_counts(dem, counts, num_shots);
+
+  auto flat = out_dem.flattened();
+  ASSERT_EQ(out_dem.count_errors(), 2);
+  ASSERT_GE(flat.instructions.size(), 2);
+
+  EXPECT_EQ(flat.instructions[0].type,
+            stim::DemInstructionType::DEM_ERROR);
+  EXPECT_NEAR(flat.instructions[0].arg_data[0], 0.1, 1e-9);
+  ASSERT_EQ(flat.instructions[1].type,
+            stim::DemInstructionType::DEM_ERROR);
+  EXPECT_NEAR(flat.instructions[1].arg_data[0], 0.4, 1e-9);
+}
+
+TEST(common, DemFromCountsSimpleTwoErrors) {
+  stim::DetectorErrorModel dem(R"DEM(
+        error(0.25) D0
+        error(0.35) D1
+        detector(0, 0, 0) D0
+        detector(0, 0, 0) D1
+      )DEM");
+
+  std::vector<size_t> counts{5, 7};
+  size_t num_shots = 20;
+  stim::DetectorErrorModel out_dem =
+      common::dem_from_counts(dem, counts, num_shots);
+
+  auto flat = out_dem.flattened();
+  ASSERT_EQ(out_dem.count_errors(), 2);
+
+  ASSERT_GE(flat.instructions.size(), 2);
+  EXPECT_EQ(flat.instructions[0].type,
+            stim::DemInstructionType::DEM_ERROR);
+  EXPECT_NEAR(flat.instructions[0].arg_data[0], 0.25, 1e-9);
+  EXPECT_EQ(flat.instructions[1].type,
+            stim::DemInstructionType::DEM_ERROR);
+  EXPECT_NEAR(flat.instructions[1].arg_data[0], 0.35, 1e-9);
+}


### PR DESCRIPTION
## Summary
- ensure `dem_from_counts` always advances error counter
- test DEM conversion when zero-probability errors are present
- add simple two-error DEM test
- update BUILD so common tests link with LTO settings

## Testing
- `bazel test //src:common_tests --test_output=errors`


------
https://chatgpt.com/codex/tasks/task_e_6842168a59388320a1971cc21c7bce6c