### PR TITLE
Add BFS detector ordering option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We tested the Tesseract decoder for:
 *   **Detailed Statistics:** provides comprehensive statistics output, including shot counts, error
     counts, and processing times.
 *   **Heuristics**: includes flexible heuristic options: `--beam`, `--det-penalty`,
-    `--beam-climbing`, `--no-revisit-dets`, `--at-most-two-errors-per-detector` and `--pqlimit` to
+    `--beam-climbing`, `--no-revisit-dets`, `--at-most-two-errors-per-detector`, `--det-order-bfs` and `--pqlimit` to
     improve performance while maintaining a low logical error rate. To learn more about these
     options, use `./bazel-bin/src/tesseract --help`
 

--- a/src/tesseract_main.cc
+++ b/src/tesseract_main.cc
@@ -15,6 +15,9 @@
 #include <argparse/argparse.hpp>
 #include <atomic>
 #include <fstream>
+#include <queue>
+#include <algorithm>
+#include <numeric>
 #include <nlohmann/json.hpp>
 #include <thread>
 
@@ -30,6 +33,7 @@ struct Args {
   // Manifold orientation options
   uint64_t det_order_seed;
   size_t num_det_orders = 10;
+  bool det_order_bfs = false;
 
   // Sampling options
   size_t sample_num_shots = 0;
@@ -177,59 +181,101 @@ struct Args {
       std::mt19937_64 rng(det_order_seed);
       std::normal_distribution<double> dist(/*mean=*/0, /*stddev=*/1);
 
-      std::vector<std::vector<double>> detector_coords =
-          get_detector_coords(config.dem);
-      if (verbose) {
-        for (size_t d = 0; d < detector_coords.size(); ++d) {
-          std::cout << "Detector D" << d << " coordinate (";
-          size_t e = std::min(3ul, detector_coords[d].size());
-          for (size_t i = 0; i < e; ++i) {
-            std::cout << detector_coords[d][i];
-            if (i + 1 < e) std::cout << ", ";
-          }
-          std::cout << ")" << std::endl;
-        }
-      }
-
-      std::vector<double> inner_products(config.dem.count_detectors());
-
-      if (!detector_coords.size() or !detector_coords.at(0).size()) {
-        // If there are no detector coordinates, just use the standard ordering
-        // of the indices.
+      if (det_order_bfs) {
+        auto graph = build_detector_graph(config.dem);
+        std::uniform_int_distribution<size_t> dist_det(0, graph.size() - 1);
         for (size_t det_order = 0; det_order < num_det_orders; ++det_order) {
-          config.det_orders.emplace_back();
-          std::iota(config.det_orders.back().begin(),
-                    config.det_orders.front().end(), 0);
-        }
-      } else {
-        // Use the coordinates to order the detectors based on a random
-        // orientation
-        for (size_t det_order = 0; det_order < num_det_orders; ++det_order) {
-          // Sample a direction
-          std::vector<double> orientation_vector;
-          for (size_t i = 0; i < detector_coords.at(0).size(); ++i) {
-            orientation_vector.push_back(dist(rng));
-          }
-
-          for (size_t i = 0; i < detector_coords.size(); ++i) {
-            inner_products[i] = 0;
-            for (size_t j = 0; j < orientation_vector.size(); ++j) {
-              inner_products[i] +=
-                  detector_coords[i][j] * orientation_vector[j];
+          std::vector<size_t> perm;
+          perm.reserve(graph.size());
+          std::vector<char> visited(graph.size(), false);
+          std::queue<size_t> q;
+          size_t start = dist_det(rng);
+          while (perm.size() < graph.size()) {
+            if (!visited[start]) {
+              visited[start] = true;
+              q.push(start);
+              perm.push_back(start);
+            }
+            while (!q.empty()) {
+              size_t cur = q.front();
+              q.pop();
+              auto neigh = graph[cur];
+              std::shuffle(neigh.begin(), neigh.end(), rng);
+              for (size_t n : neigh) {
+                if (!visited[n]) {
+                  visited[n] = true;
+                  q.push(n);
+                  perm.push_back(n);
+                }
+              }
+            }
+            if (perm.size() < graph.size()) {
+              do {
+                start = dist_det(rng);
+              } while (visited[start]);
             }
           }
-          std::vector<size_t> perm(config.dem.count_detectors());
-          std::iota(perm.begin(), perm.end(), 0);
-          std::sort(perm.begin(), perm.end(),
-                    [&](const size_t& i, const size_t& j) {
-                      return inner_products[i] > inner_products[j];
-                    });
-          // Invert the permutation
-          std::vector<size_t> inv_perm(config.dem.count_detectors());
+          std::vector<size_t> inv_perm(graph.size());
           for (size_t i = 0; i < perm.size(); ++i) {
             inv_perm[perm[i]] = i;
           }
           config.det_orders[det_order] = inv_perm;
+        }
+      } else {
+        std::vector<std::vector<double>> detector_coords =
+            get_detector_coords(config.dem);
+        if (verbose) {
+          for (size_t d = 0; d < detector_coords.size(); ++d) {
+            std::cout << "Detector D" << d << " coordinate (";
+            size_t e = std::min(3ul, detector_coords[d].size());
+            for (size_t i = 0; i < e; ++i) {
+              std::cout << detector_coords[d][i];
+              if (i + 1 < e) std::cout << ", ";
+            }
+            std::cout << ")" << std::endl;
+          }
+        }
+
+        std::vector<double> inner_products(config.dem.count_detectors());
+
+        if (!detector_coords.size() || !detector_coords.at(0).size()) {
+          // If there are no detector coordinates, just use the standard ordering
+          // of the indices.
+          for (size_t det_order = 0; det_order < num_det_orders; ++det_order) {
+            config.det_orders.emplace_back();
+            std::iota(config.det_orders.back().begin(),
+                      config.det_orders.front().end(), 0);
+          }
+        } else {
+          // Use the coordinates to order the detectors based on a random
+          // orientation
+          for (size_t det_order = 0; det_order < num_det_orders; ++det_order) {
+            // Sample a direction
+            std::vector<double> orientation_vector;
+            for (size_t i = 0; i < detector_coords.at(0).size(); ++i) {
+              orientation_vector.push_back(dist(rng));
+            }
+
+            for (size_t i = 0; i < detector_coords.size(); ++i) {
+              inner_products[i] = 0;
+              for (size_t j = 0; j < orientation_vector.size(); ++j) {
+                inner_products[i] +=
+                    detector_coords[i][j] * orientation_vector[j];
+              }
+            }
+            std::vector<size_t> perm(config.dem.count_detectors());
+            std::iota(perm.begin(), perm.end(), 0);
+            std::sort(perm.begin(), perm.end(),
+                      [&](const size_t& i, const size_t& j) {
+                        return inner_products[i] > inner_products[j];
+                      });
+            // Invert the permutation
+            std::vector<size_t> inv_perm(config.dem.count_detectors());
+            for (size_t i = 0; i < perm.size(); ++i) {
+              inv_perm[perm[i]] = i;
+            }
+            config.det_orders[det_order] = inv_perm;
+          }
         }
       }
     }
@@ -358,6 +404,10 @@ int main(int argc, char* argv[]) {
       .metavar("N")
       .default_value(size_t(1))
       .store_into(args.num_det_orders);
+  program.add_argument("--det-order-bfs")
+      .help("Use BFS-based detector ordering instead of geometric orientation")
+      .flag()
+      .store_into(args.det_order_bfs);
   program.add_argument("--det-order-seed")
       .help(
           "Seed used when initializing the random detector traversal "

--- a/src/utils.h
+++ b/src/utils.h
@@ -31,6 +31,11 @@ constexpr const double EPSILON = 1e-7;
 std::vector<std::vector<double>> get_detector_coords(
     stim::DetectorErrorModel& dem);
 
+// Builds an adjacency list graph where two detectors share an edge iff an error
+// in the model activates them both.
+std::vector<std::vector<size_t>> build_detector_graph(
+    const stim::DetectorErrorModel& dem);
+
 const double INF = std::numeric_limits<double>::infinity();
 
 bool sampling_from_dem(uint64_t seed, size_t num_shots,


### PR DESCRIPTION
## Summary
- add new CLI flag `--det-order-bfs`
- implement BFS-based detector ordering
- expose detector graph builder in utils
- document flag in README

## Testing
- `bazel test //src:all` *(fails: Build did NOT complete successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68477f45241c8320825230de8a01e882