### PR TITLE
Add configurable test modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ Tesseract uses [Bazel](https://bazel.build/) as its build system. To build the d
 bazel build src:all
 ```
 
+## Running Tests
+
+Unit tests are executed with Bazel. Run the quick test suite using:
+```bash
+bazel test //src:all
+```
+By default the tests use reduced parameters and finish in under 30 seconds.
+To run a more exhaustive suite with additional shots and larger distances, set:
+```bash
+TESSERACT_LONG_TESTS=1 bazel test //src:all
+```
+
+
 ## Usage
 
 The file `tesseract_main.cc` provides the main entry point for Tesseract Decoder. It can decode

--- a/src/tesseract.test.cc
+++ b/src/tesseract.test.cc
@@ -15,6 +15,7 @@
 #include "tesseract.h"
 
 #include <vector>
+#include <cstdlib>
 
 #include "gtest/gtest.h"
 #include "simplex.h"
@@ -79,10 +80,19 @@ bool simplex_test_compare(stim::DetectorErrorModel& dem,
 }
 
 TEST(tesseract, Tesseract_simplex_test) {
-  for (float p_err : {0.001, 0.003, 0.005}) {
-    for (size_t distance : {3, 5}) {
-      for (const size_t num_rounds : {2, 5, 10}) {
-        const size_t num_shots = 1000 / num_rounds / distance;
+  bool long_tests = std::getenv("TESSERACT_LONG_TESTS") != nullptr;
+  auto p_errs = long_tests ? std::vector<float>{0.001f, 0.003f, 0.005f}
+                           : std::vector<float>{0.003f};
+  auto distances = long_tests ? std::vector<size_t>{3, 5, 7}
+                              : std::vector<size_t>{3};
+  auto rounds = long_tests ? std::vector<size_t>{2, 5, 10}
+                           : std::vector<size_t>{2};
+  size_t base_shots = long_tests ? 1000 : 100;
+
+  for (float p_err : p_errs) {
+    for (size_t distance : distances) {
+      for (const size_t num_rounds : rounds) {
+        const size_t num_shots = base_shots / num_rounds / distance;
         std::cout << "p_err = " << p_err << " distance = " << distance
                   << " num_rounds = " << num_rounds
                   << " num_shots = " << num_shots << std::endl;


### PR DESCRIPTION
## Summary
- allow running a short or extended test suite via `TESSERACT_LONG_TESTS`
- document the new environment variable in the README

## Testing
- `bazel test //src:common_tests //src:tesseract_tests --test_output=errors`

------
https://chatgpt.com/codex/tasks/task_e_68478291e7b48320bf6801478c41b5c9