### PR TITLE
Add Python interface and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,12 @@ jobs:
 
     - name: Bazel tests
       run: bazel test src:all
+
+    - name: Build Python module
+      run: bazel build //src:tesseract_decoder
+
+    - name: Run Python tests
+      run: |
+        pip install pytest stim
+        export PYTHONPATH=$(pwd)/bazel-bin/src
+        pytest -v tests

--- a/README.md
+++ b/README.md
@@ -82,6 +82,27 @@ To run a more exhaustive suite with additional shots and larger distances, set:
 TESSERACT_LONG_TESTS=1 bazel test //src:all
 ```
 
+### Python Module
+
+A minimal Python wrapper is also provided. Build it with:
+
+```bash
+bazel build //src:tesseract_decoder
+```
+
+Add the build output directory to `PYTHONPATH` to use the module:
+
+```bash
+export PYTHONPATH=$(bazel info bazel-bin)/src
+python -c "import tesseract_decoder"
+```
+
+Python tests can be run using:
+
+```bash
+PYTHONPATH=$(bazel info bazel-bin)/src pytest
+```
+
 
 ## Usage
 

--- a/src/BUILD
+++ b/src/BUILD
@@ -66,13 +66,8 @@ cc_library(
 
 pybind_extension(
     name = "tesseract_decoder",
-    srcs = [
-        "common.pybind.h",
-        "tesseract.pybind.cc",
-    ],
-    deps = [
-        ":libcommon",
-    ],
+    srcs = ["tesseract.pybind.cc"],
+    deps = [":libtesseract"],
 )
 
 

--- a/src/tesseract.pybind.cc
+++ b/src/tesseract.pybind.cc
@@ -1,6 +1,35 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
-#include "common.pybind.h"
-#include "pybind11/detail/common.h"
+#include "stim.h"
+#include "tesseract.h"
 
-PYBIND11_MODULE(tesseract_py, m) { add_common_module(m); }
+namespace py = pybind11;
+
+struct CompiledDecoder {
+  TesseractDecoder decoder;
+
+  static CompiledDecoder from_dem(const py::object &dem_obj) {
+    std::string dem_str = py::str(dem_obj);
+    stim::DetectorErrorModel dem(dem_str.c_str());
+    TesseractConfig cfg{dem};
+    return CompiledDecoder{TesseractDecoder(cfg)};
+  }
+
+  uint64_t decode(const py::iterable &det_events) {
+    std::vector<uint64_t> dets;
+    for (const auto &d : det_events) {
+      dets.push_back(py::cast<uint64_t>(d));
+    }
+    return decoder.decode(dets);
+  }
+};
+
+PYBIND11_MODULE(tesseract_decoder, m) {
+  py::class_<CompiledDecoder>(m, "CompiledDecoder")
+      .def_static("from_dem", &CompiledDecoder::from_dem, py::arg("dem"))
+      .def("decode", &CompiledDecoder::decode, py::arg("detections"));
+
+  m.def("compile_decoder_for_dem", &CompiledDecoder::from_dem,
+        py::arg("dem"));
+}

--- a/tests/test_tesseract_decoder.py
+++ b/tests/test_tesseract_decoder.py
@@ -1,0 +1,12 @@
+import tesseract_decoder
+
+def test_simple_decode():
+    dem = """
+error(0.5) D0 L0
+error(0.5) D1
+detector(0,0,0) D0
+detector(0,0,0) D1
+"""
+    dec = tesseract_decoder.compile_decoder_for_dem(dem)
+    assert dec.decode([0]) == 1
+    assert dec.decode([]) == 0


### PR DESCRIPTION
## Summary
- expose a minimal `tesseract_decoder` Python module via pybind11
- build the module using libtesseract
- add CI steps and pytest exercising the module
- document Python build/test instructions in README

## Testing
- `bazel test //src:common_tests --test_output=errors`
- `bazel build //src:tesseract_decoder`
- `PYTHONPATH=$(pwd)/bazel-bin/src python3.12 -m pytest -q tests/test_tesseract_decoder.py`

------
https://chatgpt.com/codex/tasks/task_e_6847ab26e29c83209c964cee42909ef6