### PR TITLE
Add BFS detector coordinate logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ We tested the Tesseract decoder for:
     `--beam-climbing`, `--no-revisit-dets`, `--at-most-two-errors-per-detector`, `--det-order-bfs` and `--pqlimit` to
     improve performance while maintaining a low logical error rate. To learn more about these
     options, use `./bazel-bin/src/tesseract --help`
-*   **Visualization tool:** open the [viz directory](viz/) in your browser to view decoding results.
+*   **Visualization tool:** open the [viz directory](viz/) in your browser to view decoding results. See [viz/README.md](viz/README.md) for instructions on generating the visualization JSON.
 
 ## Installation
 

--- a/src/tesseract_main.cc
+++ b/src/tesseract_main.cc
@@ -182,6 +182,20 @@ struct Args {
       std::mt19937_64 rng(det_order_seed);
       std::normal_distribution<double> dist(/*mean=*/0, /*stddev=*/1);
 
+      std::vector<std::vector<double>> detector_coords =
+          get_detector_coords(config.dem);
+      if (verbose) {
+        for (size_t d = 0; d < detector_coords.size(); ++d) {
+          std::cout << "Detector D" << d << " coordinate (";
+          size_t e = std::min(3ul, detector_coords[d].size());
+          for (size_t i = 0; i < e; ++i) {
+            std::cout << detector_coords[d][i];
+            if (i + 1 < e) std::cout << ", ";
+          }
+          std::cout << ")" << std::endl;
+        }
+      }
+
       if (det_order_bfs) {
         auto graph = build_detector_graph(config.dem);
         std::uniform_int_distribution<size_t> dist_det(0, graph.size() - 1);
@@ -223,20 +237,6 @@ struct Args {
           config.det_orders[det_order] = inv_perm;
         }
       } else {
-        std::vector<std::vector<double>> detector_coords =
-            get_detector_coords(config.dem);
-        if (verbose) {
-          for (size_t d = 0; d < detector_coords.size(); ++d) {
-            std::cout << "Detector D" << d << " coordinate (";
-            size_t e = std::min(3ul, detector_coords[d].size());
-            for (size_t i = 0; i < e; ++i) {
-              std::cout << detector_coords[d][i];
-              if (i + 1 < e) std::cout << ", ";
-            }
-            std::cout << ")" << std::endl;
-          }
-        }
-
         std::vector<double> inner_products(config.dem.count_detectors());
 
         if (!detector_coords.size() || !detector_coords.at(0).size()) {

--- a/viz/README.md
+++ b/viz/README.md
@@ -1,0 +1,34 @@
+# Visualization
+
+This tool displays the detectors and errors from a Tesseract decoding run in 3D.
+
+## Generating the JSON
+
+Use the `--verbose` flag when running the decoder and filter the output to
+include only the lines used by the converter script:
+
+```bash
+bazel build src:all && \
+./bazel-bin/src/tesseract --pqlimit 200000 --beam 5 --num-det-orders 20 \
+  --sample-num-shots 1 --det-order-seed 13267562 --det-order-bfs \
+  --circuit testdata/colorcodes/r\=9\,d\=9\,p\=0.002\,noise\=si1000\,c\=superdense_color_code_X\,q\=121\,gates\=cz.stim \
+  --sample-seed 717347 --threads 60 --verbose | \
+  grep -E 'Error|Detector|activated_errors|activated_dets' > logfile.txt
+
+python viz/to_json.py logfile.txt -o logfile.json
+```
+
+
+The `--det-order-bfs` flag is compatible with visualization logs. Just make
+sure `--verbose` is enabled so the detector coordinates are printed for
+`to_json.py` to parse.
+
+The `to_json.py` script produces `logfile.json`, which contains the detector
+coordinates and animation frames for the viewer.
+
+## Viewing
+
+Open `viz/index.html` in a modern browser. It will automatically try to load
+`logfile.json` from the same directory. If the file picker is used, any JSON
+produced by `to_json.py` can be visualized.
+

--- a/viz/index.html
+++ b/viz/index.html
@@ -314,6 +314,18 @@ function toggleAnimation() {
   if (playing && frames.length) restartAnimationTimer();
   else clearInterval(animationTimer);
 }
+
+// Try to load a default logfile when the page is opened.
+window.addEventListener('load', () => {
+  fetch('logfile.json')
+    .then(r => r.ok ? r.json() : Promise.reject())
+    .then(data => initializeScene(
+      data.detectorCoords,
+      data.errorCoords,
+      data.frames,
+      data.errorToDetectors))
+    .catch(() => {/* ignore if not present */});
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- print detector coordinates even when `--det-order-bfs` is used
- clarify BFS compatibility in visualization docs

## Testing
- `bazel test //src:all`


------
https://chatgpt.com/codex/tasks/task_e_6847aa8301808320ae645aa493962bb5