### PR TITLE
Add flexible redundancy detection and CLI

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -141,6 +141,9 @@ cc_test(
     srcs = ["common.test.cc"],
     copts = OPT_COPTS,
     linkopts = OPT_LINKOPTS,
+    data = [
+        "//testdata:all_files",
+    ],
     linkstatic = True,
     deps = [
         ":libcommon",
@@ -192,6 +195,18 @@ cc_binary(
         ":libsimplex",
         "@argparse",
         "@nlohmann_json//:json",
+    ],
+)
+
+cc_binary(
+    name = "dem_stats",
+    srcs = ["dem_stats_main.cc"],
+    copts = OPT_COPTS,
+    linkopts = OPT_LINKOPTS,
+    deps = [
+        ":libcommon",
+        "@argparse",
+        "@stim//:stim_lib",
     ],
 )
 

--- a/src/common.h
+++ b/src/common.h
@@ -84,6 +84,11 @@ stim::DetectorErrorModel dem_from_counts(
     stim::DetectorErrorModel& orig_dem, const std::vector<size_t>& error_counts,
     size_t num_shots);
 
+// Returns the indices of errors in the detector error model that have a
+// strictly higher cost than some combination of other errors producing the same
+// set of detectors.
+std::vector<size_t> find_redundant_errors(const stim::DetectorErrorModel& dem);
+
 }  // namespace common
 
 #endif

--- a/src/dem_stats_main.cc
+++ b/src/dem_stats_main.cc
@@ -1,0 +1,45 @@
+#include <argparse/argparse.hpp>
+#include <fstream>
+#include <iostream>
+
+#include "stim.h"
+#include "common.h"
+
+int main(int argc, char **argv) {
+    argparse::ArgumentParser program("dem_stats");
+    std::string dem_path;
+    bool no_merge_errors = false;
+    program.add_argument("--dem")
+        .required()
+        .help("Path to detector error model")
+        .store_into(dem_path);
+    program.add_argument("--no-merge-errors")
+        .help("Do not merge identical error mechanisms before analysis")
+        .flag()
+        .store_into(no_merge_errors);
+    try {
+        program.parse_args(argc, argv);
+    } catch (const std::exception &e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << program;
+        return EXIT_FAILURE;
+    }
+
+    FILE *f = fopen(dem_path.c_str(), "r");
+    if (!f) {
+        std::cerr << "Failed to open " << dem_path << std::endl;
+        return EXIT_FAILURE;
+    }
+    stim::DetectorErrorModel dem = stim::DetectorErrorModel::from_file(f);
+    fclose(f);
+
+    if (!no_merge_errors) {
+        dem = common::merge_identical_errors(dem);
+    }
+    dem = common::remove_zero_probability_errors(dem);
+    auto redund = common::find_redundant_errors(dem);
+
+    std::cout << redund.size() << " of " << dem.count_errors()
+              << " errors are redundant" << std::endl;
+    return 0;
+}

--- a/testdata/BUILD
+++ b/testdata/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "all_files",
+    srcs = glob(["**/*.stim", "README.md"]),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
## Summary
- rework `find_redundant_errors` to support arbitrary detector counts
- expose `dem_stats` CLI for inspecting redundant errors in a DEM
- adjust BUILD files

## Testing
- `bazel test //src:common_tests --test_output=errors`
- `bazel build //src:dem_stats`


------
https://chatgpt.com/codex/tasks/task_e_6847ac30357c8320af46d02e1aeb893e