### PR TITLE
Switch container for visited detectors to robin_map

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -115,3 +115,16 @@ http_archive(
   sha256 = "d0a116e91f64a4a2d8fb7590c34242df92258a61ec644b79127951e821b47be6",
   urls = ["https://github.com/pybind/pybind11/archive/v2.13.6.zip"],
 )
+
+ROBIN_MAP_VERSION = "1.4.0"
+ROBIN_MAP_SHA256 = "7930dbf9634acfc02686d87f615c0f4f33135948130b8922331c16d90a03250c"
+
+http_archive(
+    name = "robin_map",
+    sha256 = ROBIN_MAP_SHA256,
+    strip_prefix = "robin-map-" + ROBIN_MAP_VERSION,
+    urls = [
+        "https://github.com/Tessil/robin-map/archive/refs/tags/v" + ROBIN_MAP_VERSION + ".tar.gz",
+    ],
+    build_file = "//external:robin_map.BUILD",
+)

--- a/external/robin_map.BUILD
+++ b/external/robin_map.BUILD
@@ -1,0 +1,6 @@
+cc_library(
+    name = "robin_map",
+    hdrs = glob(["include/tsl/*.h"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/src/BUILD
+++ b/src/BUILD
@@ -104,6 +104,7 @@ cc_library(
     linkopts = OPT_LINKOPTS,
     deps = [
         ":libutils",
+        "@robin_map//:robin_map",
     ],
 )
 

--- a/src/tesseract.cc
+++ b/src/tesseract.cc
@@ -209,8 +209,8 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
   }
 
   std::priority_queue<QNode, std::vector<QNode>, std::greater<QNode>> pq;
-  std::unordered_map<size_t,
-                     std::unordered_set<std::vector<char>, VectorCharHash>>
+  tsl::robin_map<size_t,
+                 tsl::robin_set<std::vector<char>, VectorCharHash>>
       discovered_dets;
 
   size_t min_num_dets = detections.size();

--- a/src/tesseract.h
+++ b/src/tesseract.h
@@ -20,6 +20,8 @@
 #include <unordered_map>
 #include <vector>
 #include <unordered_set>
+#include <tsl/robin_map.h>
+#include <tsl/robin_set.h>
 
 #include "common.h"
 #include "stim.h"


### PR DESCRIPTION
## Summary
- add Tessil robin-map as a workspace dependency
- expose a build target for the header-only library
- link `libtesseract` against `robin_map`
- include robin_map headers in the decoder
- store discovered detector sets in `tsl::robin_map`/`robin_set`

## Testing
- `bazel test //src:all`
- `./bazel-bin/src/tesseract --circuit testdata/colorcodes/r=7,d=7,p=0.002,noise=si1000,c=superdense_color_code_X,q=73,gates=cz.stim --sample-num-shots 100 --sample-seed 39346 --beam 15 --pqlimit 200000 --stats-out -`


------
https://chatgpt.com/codex/tasks/task_e_68477e6becac832087200ce52876cd44