### PR TITLE
Silence unused model_status warning

### DIFF
--- a/src/simplex.cc
+++ b/src/simplex.cc
@@ -305,7 +305,8 @@ void SimplexDecoder::decode_to_errors(const std::vector<uint64_t>& detections) {
     }
 
     // Get the model status
-    const HighsModelStatus& model_status = highs->getModelStatus();
+    [[maybe_unused]] const HighsModelStatus& model_status =
+        highs->getModelStatus();
     assert(model_status == HighsModelStatus::kOptimal);
   }
 


### PR DESCRIPTION
## Summary
- mark `model_status` as `[[maybe_unused]]` in `decode_to_errors`

## Testing
- `bazel test //src:all`

------
https://chatgpt.com/codex/tasks/task_e_6847b62964a48320b2cc073bcb5e5a71