### PR TITLE
Implement lazy detcost evaluation

### DIFF
--- a/src/tesseract.h
+++ b/src/tesseract.h
@@ -46,6 +46,7 @@ public:
   double cost;
   size_t num_dets;
   std::vector<char> blocked_errs;
+  std::vector<size_t> det_counts;
 
   bool operator>(const Node &other) const;
 };


### PR DESCRIPTION
## Summary
- precompute minimal det-cost per detector for quick lower bounds
- mark queue nodes when their costs use these lower bounds
- recompute exact detector costs when popping loose nodes

## Testing
- `bazel test //src:all`

------
https://chatgpt.com/codex/tasks/task_e_6848f092f51c83209e796103de35aa20