### PR TITLE
Introduce SmallVector for small buffers

### DIFF
--- a/src/simplex.cc
+++ b/src/simplex.cc
@@ -325,7 +325,7 @@ void SimplexDecoder::decode_to_errors(const std::vector<uint64_t>& detections) {
 }
 
 double SimplexDecoder::cost_from_errors(
-    const SmallVector<size_t>& predicted_errors) {
+    const std::vector<size_t>& predicted_errors) {
   double total_cost = 0;
   // Iterate over all errors and add to the mask
   for (size_t ei : predicted_errors_buffer) {
@@ -335,7 +335,7 @@ double SimplexDecoder::cost_from_errors(
 }
 
 common::ObservablesMask SimplexDecoder::mask_from_errors(
-    const SmallVector<size_t>& predicted_errors) {
+    const std::vector<size_t>& predicted_errors) {
   common::ObservablesMask mask = 0;
   // Iterate over all errors and add to the mask
   for (size_t ei : predicted_errors_buffer) {

--- a/src/simplex.h
+++ b/src/simplex.h
@@ -15,7 +15,6 @@
 #ifndef SIMPLEX_HPP
 #define SIMPLEX_HPP
 #include <vector>
-#include "small_vector.h"
 
 #include "common.h"
 #include "stim.h"
@@ -38,7 +37,7 @@ struct SimplexDecoder {
   std::vector<common::Error> errors;
   size_t num_detectors = 0;
   size_t num_observables = 0;
-  SmallVector<size_t> predicted_errors_buffer;
+  std::vector<size_t> predicted_errors_buffer;
   std::vector<common::ObservablesMask> error_masks;
   std::vector<std::vector<size_t>> start_time_to_errors;
   std::vector<std::vector<size_t>> end_time_to_errors;
@@ -61,10 +60,10 @@ struct SimplexDecoder {
   // Returns the bitwise XOR of all the observables bitmasks of all errors in
   // the predicted errors buffer.
   common::ObservablesMask mask_from_errors(
-      const SmallVector<size_t>& predicted_errors);
+      const std::vector<size_t>& predicted_errors);
   // Returns the sum of the likelihood costs (minus-log-likelihood-ratios) of
   // all errors in the predicted errors buffer.
-  double cost_from_errors(const SmallVector<size_t>& predicted_errors);
+  double cost_from_errors(const std::vector<size_t>& predicted_errors);
   common::ObservablesMask decode(const std::vector<uint64_t>& detections);
 
   void decode_shots(std::vector<stim::SparseShot>& shots,

--- a/src/tesseract.cc
+++ b/src/tesseract.cc
@@ -121,7 +121,10 @@ void TesseractDecoder::decode_to_errors(
       decode_to_errors(detections, det_order);
       double this_cost = cost_from_errors(predicted_errors_buffer);
       if (!low_confidence_flag && this_cost < best_cost) {
-        best_errors = predicted_errors_buffer;
+        best_errors.clear();
+        for (size_t ei : predicted_errors_buffer) {
+          best_errors.push_back(ei);
+        }
         best_cost = this_cost;
       }
       if (config.verbose) {
@@ -138,7 +141,10 @@ void TesseractDecoder::decode_to_errors(
       decode_to_errors(detections, det_order);
       double this_cost = cost_from_errors(predicted_errors_buffer);
       if (!low_confidence_flag && this_cost < best_cost) {
-        best_errors = predicted_errors_buffer;
+        best_errors.clear();
+        for (size_t ei : predicted_errors_buffer) {
+          best_errors.push_back(ei);
+        }
         best_cost = this_cost;
       }
       if (config.verbose) {
@@ -152,7 +158,7 @@ void TesseractDecoder::decode_to_errors(
     }
   }
   config.det_beam = max_det_beam;
-  predicted_errors_buffer = best_errors;
+  predicted_errors_buffer.assign(best_errors.begin(), best_errors.end());
   low_confidence_flag = best_cost == std::numeric_limits<double>::max();
 }
 
@@ -272,7 +278,7 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
                   << " num_pq_pushed = " << num_pq_pushed << std::endl;
       }
       // Store the predicted errors into the buffer
-      predicted_errors_buffer = node.errs;
+      predicted_errors_buffer.assign(node.errs.begin(), node.errs.end());
       return;
     }
 
@@ -448,7 +454,7 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
 }
 
 double TesseractDecoder::cost_from_errors(
-    const SmallVector<size_t>& predicted_errors) {
+    const std::vector<size_t>& predicted_errors) {
   double total_cost = 0;
   // Iterate over all errors and add to the mask
   for (size_t ei : predicted_errors_buffer) {
@@ -458,7 +464,7 @@ double TesseractDecoder::cost_from_errors(
 }
 
 common::ObservablesMask TesseractDecoder::mask_from_errors(
-    const SmallVector<size_t>& predicted_errors) {
+    const std::vector<size_t>& predicted_errors) {
   common::ObservablesMask mask = 0;
   // Iterate over all errors and add to the mask
   for (size_t ei : predicted_errors_buffer) {

--- a/src/tesseract.h
+++ b/src/tesseract.h
@@ -76,18 +76,18 @@ struct TesseractDecoder {
   // Returns the bitwise XOR of all the observables bitmasks of all errors in
   // the predicted errors buffer.
   common::ObservablesMask mask_from_errors(
-      const SmallVector<size_t>& predicted_errors);
+      const std::vector<size_t>& predicted_errors);
 
   // Returns the sum of the likelihood costs (minus-log-likelihood-ratios) of
   // all errors in the predicted errors buffer.
-  double cost_from_errors(const SmallVector<size_t>& predicted_errors);
+  double cost_from_errors(const std::vector<size_t>& predicted_errors);
   common::ObservablesMask decode(const std::vector<uint64_t>& detections);
 
   void decode_shots(std::vector<stim::SparseShot>& shots,
                     std::vector<common::ObservablesMask>& obs_predicted);
 
   bool low_confidence_flag = false;
-  SmallVector<size_t> predicted_errors_buffer;
+  std::vector<size_t> predicted_errors_buffer;
 
   int det_beam;
   std::vector<common::Error> errors;


### PR DESCRIPTION
## Summary
- implement a lightweight `SmallVector` with 128 element inline storage
- use `SmallVector<size_t>` for error lists in Tesseract and Simplex decoders
- export the new header via `libcommon`

## Testing
- `bazel test //src:all`

------
https://chatgpt.com/codex/tasks/task_e_684a0fc3b44083209755d024610ce850