### PR TITLE
Enable root builds

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,6 +11,14 @@ DEFAULT_PYTHON_VERSION = "3.11"
 python_configure = use_extension("@pybind11_bazel//:python_configure.bzl", "extension")
 use_repo(python_configure, "local_config_python")
 
+python = use_extension("@rules_python//python/extensions:python.bzl", "python")
+python.toolchain(
+    python_version = DEFAULT_PYTHON_VERSION,
+    ignore_root_user_error = True,
+    is_default = True,
+)
+use_repo(python, "python_3_11")
+
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 


### PR DESCRIPTION
## Summary
- configure rules_python toolchain with `ignore_root_user_error=True`

## Testing
- `bazel build //src:tesseract_decoder`
- `bazel test //src/py:common_test //src/py:utils_test //src/py:simplex_test //src/py:tesseract_test //src/py:requirements_test` *(fails: No matching distribution found for stim)*

------
https://chatgpt.com/codex/tasks/task_e_6859a50757e883208589908d4b12fe07