### PR TITLE
Track per-detector detcost minima

### DIFF
--- a/src/tesseract.h
+++ b/src/tesseract.h
@@ -90,6 +90,11 @@ struct TesseractDecoder {
   std::vector<size_t> predicted_errors_buffer;
   std::vector<common::Error> errors;
 
+  // Tracks how often each error attains the minimum detcost for each detector.
+  const std::vector<std::unordered_map<size_t, size_t>>& detcost_argmin_counts() const {
+    return detcost_min_error_counts;
+  }
+
  private:
   std::vector<std::vector<int>> d2e;
   std::vector<std::vector<int>> eneighbors;
@@ -97,6 +102,8 @@ struct TesseractDecoder {
   size_t num_detectors;
   size_t num_errors;
   std::vector<ErrorCost> error_costs;
+
+  mutable std::vector<std::unordered_map<size_t, size_t>> detcost_min_error_counts;
 
   void initialize_structures(size_t num_detectors);
   double get_detcost(size_t d, const std::vector<DetectorCostTuple>& detector_cost_tuples) const;


### PR DESCRIPTION
## Summary
- instrument `TesseractDecoder::get_detcost` to count which error gave the minimum
- expose and accumulate these counts across threads in `tesseract_main`
- output optional CSV via `--detcost-stats-out`

## Testing
- `bazel test //src:common_tests //src:tesseract_tests`

------
https://chatgpt.com/codex/tasks/task_e_685dcee730c08320a1351dff1c606d1a