### PR TITLE
Make simplex init_ilp private and remove binding

### DIFF
--- a/src/py/simplex_test.py
+++ b/src/py/simplex_test.py
@@ -41,7 +41,6 @@ def test_create_simplex_decoder():
     decoder = tesseract_decoder.simplex.SimplexDecoder(
         tesseract_decoder.simplex.SimplexConfig(_DETECTOR_ERROR_MODEL, window_length=5)
     )
-    decoder.init_ilp()
     decoder.decode_to_errors([1])
     assert decoder.get_observables_from_errors([1]) == []
     assert decoder.cost_from_errors([2]) == pytest.approx(1.0986123)
@@ -67,7 +66,6 @@ def test_simplex_decoder_predicts_various_observable_flips():
         # Initialize SimplexConfig and SimplexDecoder with the generated DEM
         config = tesseract_decoder.simplex.SimplexConfig(dem, window_length=1) # window_length must be set
         decoder = tesseract_decoder.simplex.SimplexDecoder(config)
-        decoder.init_ilp() # Initialize the ILP solver
 
         # Simulate a detection event on D0.
         # The decoder should identify the most likely error causing D0,

--- a/src/simplex.h
+++ b/src/simplex.h
@@ -56,8 +56,6 @@ struct SimplexDecoder {
 
   SimplexDecoder(SimplexConfig config);
 
-  void init_ilp();
-
   // Clears the predicted_errors_buffer and fills it with the decoded errors for
   // these detection events.
   void decode_to_errors(const std::vector<uint64_t>& detections);
@@ -73,6 +71,9 @@ struct SimplexDecoder {
                     std::vector<std::vector<int>>& obs_predicted);
 
   ~SimplexDecoder();
+
+ private:
+  void init_ilp();
 };
 
 #endif  // SIMPLEX_HPP

--- a/src/simplex.pybind.h
+++ b/src/simplex.pybind.h
@@ -62,7 +62,6 @@ void add_simplex_module(py::module& root) {
       .def_readwrite("start_time_to_errors", &SimplexDecoder::start_time_to_errors)
       .def_readwrite("end_time_to_errors", &SimplexDecoder::end_time_to_errors)
       .def_readonly("low_confidence_flag", &SimplexDecoder::low_confidence_flag)
-      .def("init_ilp", &SimplexDecoder::init_ilp)
       .def("decode_to_errors", &SimplexDecoder::decode_to_errors, py::arg("detections"))
       .def(
           "get_observables_from_errors",


### PR DESCRIPTION
## Summary
- hide SimplexDecoder::init_ilp behind a private interface
- drop init_ilp from the Python API and tests

## Testing
- `bazel test //src/py:simplex_test` *(fails: certificate_unknown when fetching registry)*

------
https://chatgpt.com/codex/tasks/task_e_6892ece050a88320b04f8419be390a0e