### PR TITLE
feat: add verbose callback for decoders

### DIFF
--- a/src/py/common_test.py
+++ b/src/py/common_test.py
@@ -15,7 +15,7 @@
 import pytest
 import stim
 
-from src import tesseract_decoder
+import tesseract_decoder
 
 def get_set_bits(n):
     """

--- a/src/py/simplex_test.py
+++ b/src/py/simplex_test.py
@@ -16,7 +16,7 @@ import math
 import pytest
 import stim
 
-from src import tesseract_decoder
+import tesseract_decoder
 
 _DETECTOR_ERROR_MODEL = stim.DetectorErrorModel(
     """
@@ -33,7 +33,7 @@ def test_create_simplex_config():
     assert sc.window_length == 5
     assert (
         str(sc)
-        == "SimplexConfig(dem=DetectorErrorModel_Object, window_length=5, window_slide_length=0, verbose=0)"
+        == "SimplexConfig(dem=DetectorErrorModel_Object, window_length=5, window_slide_length=0)"
     )
 
 
@@ -45,6 +45,20 @@ def test_create_simplex_decoder():
     assert decoder.get_observables_from_errors([1]) == []
     assert decoder.cost_from_errors([2]) == pytest.approx(1.0986123)
     assert decoder.decode([1]) == []
+
+
+def test_simplex_verbose_callback_receives_output():
+    lines = []
+
+    def cb(s: str) -> None:
+        lines.append(s)
+
+    config = tesseract_decoder.simplex.SimplexConfig(
+        _DETECTOR_ERROR_MODEL, window_length=5, verbose_callback=cb
+    )
+    decoder = tesseract_decoder.simplex.SimplexDecoder(config)
+    decoder.decode_to_errors([1])
+    assert any(lines)
 
 def test_simplex_decoder_predicts_various_observable_flips():
     """

--- a/src/py/tesseract_test.py
+++ b/src/py/tesseract_test.py
@@ -16,7 +16,7 @@ import math
 import pytest
 import stim
 
-from src import tesseract_decoder
+import tesseract_decoder
 
 _DETECTOR_ERROR_MODEL = stim.DetectorErrorModel(
     """
@@ -30,7 +30,7 @@ error(0.25) D1
 def test_create_config():
     assert (
         str(tesseract_decoder.tesseract.TesseractConfig(_DETECTOR_ERROR_MODEL))
-        == "TesseractConfig(dem=DetectorErrorModel_Object, det_beam=65535, no_revisit_dets=0, at_most_two_errors_per_detector=0, verbose=0, pqlimit=18446744073709551615, det_orders=[], det_penalty=0)"
+        == "TesseractConfig(dem=DetectorErrorModel_Object, det_beam=65535, no_revisit_dets=0, at_most_two_errors_per_detector=0, pqlimit=18446744073709551615, det_orders=[], det_penalty=0)"
     )
     assert (
         tesseract_decoder.tesseract.TesseractConfig(_DETECTOR_ERROR_MODEL).dem
@@ -51,6 +51,20 @@ def test_create_decoder():
     assert decoder.get_observables_from_errors([1]) == []
     assert decoder.cost_from_errors([1]) == pytest.approx(0.5108256237659907)
     assert decoder.decode([0]) == []
+
+
+def test_tesseract_verbose_callback_receives_output():
+    lines = []
+
+    def cb(s: str) -> None:
+        lines.append(s)
+
+    config = tesseract_decoder.tesseract.TesseractConfig(
+        _DETECTOR_ERROR_MODEL, verbose_callback=cb
+    )
+    decoder = tesseract_decoder.tesseract.TesseractDecoder(config)
+    decoder.decode_to_errors([0])
+    assert any(lines)
 
 def test_tesseract_decoder_predicts_various_observable_flips():
     """

--- a/src/py/utils_test.py
+++ b/src/py/utils_test.py
@@ -16,7 +16,7 @@ import math
 import pytest
 import stim
 
-from src import tesseract_decoder
+import tesseract_decoder
 
 
 _DETECTOR_ERROR_MODEL = stim.DetectorErrorModel(

--- a/src/simplex.cc
+++ b/src/simplex.cc
@@ -15,11 +15,20 @@
 #include "simplex.h"
 
 #include <cassert>
+#include <iostream>
 
 #include "Highs.h"
 #include "io/HMPSIO.h"
 
 constexpr size_t T_COORD = 2;
+
+namespace {
+void highs_log_cb(HighsLogType, const char* msg, void* user_data) {
+  CallbackStream* stream = static_cast<CallbackStream*>(user_data);
+  (*stream) << msg;
+  stream->flush();
+}
+}  // namespace
 
 std::string SimplexConfig::str() {
   auto& self = *this;
@@ -27,12 +36,15 @@ std::string SimplexConfig::str() {
   ss << "SimplexConfig(";
   ss << "dem=" << "DetectorErrorModel_Object" << ", ";
   ss << "window_length=" << self.window_length << ", ";
-  ss << "window_slide_length=" << self.window_slide_length << ", ";
-  ss << "verbose=" << self.verbose << ")";
+  ss << "window_slide_length=" << self.window_slide_length << ")";
   return ss.str();
 }
 
 SimplexDecoder::SimplexDecoder(SimplexConfig _config) : config(_config) {
+  if (!config.verbose_callback) {
+    config.verbose_callback = [](const std::string& s) { std::cout << s; };
+  }
+  config.log_stream.callback = config.verbose_callback;
   config.dem = common::remove_zero_probability_errors(config.dem);
   std::vector<double> detector_t_coords(config.dem.count_detectors());
   for (const stim::DemInstruction& instruction : config.dem.flattened().instructions) {
@@ -152,7 +164,11 @@ void SimplexDecoder::init_ilp() {
   // Disabled presolve entirely after encountering bugs similar to this one:
   // https://github.com/ERGO-Code/HiGHS/issues/1273
   highs->setOptionValue("presolve", "off");
-  highs->setOptionValue("output_flag", config.verbose);
+  highs->setOptionValue("output_flag", config.log_stream.active);
+  highs->setOptionValue("log_to_console", false);
+  if (config.log_stream.active) {
+    highs->setLogCallback(highs_log_cb, &config.log_stream);
+  }
 }
 
 void SimplexDecoder::decode_to_errors(const std::vector<uint64_t>& detections) {
@@ -197,9 +213,7 @@ void SimplexDecoder::decode_to_errors(const std::vector<uint64_t>& detections) {
         add_costs_for_time(t1);
         ++t1;
       }
-      if (config.verbose) {
-        std::cout << "t0 = " << t0 << " t1 = " << t1 << std::endl;
-      }
+      config.log_stream << "t0 = " << t0 << " t1 = " << t1 << std::endl;
 
       // Pass the model to HiGHS
       *return_status = highs->passModel(*model);
@@ -235,16 +249,20 @@ void SimplexDecoder::decode_to_errors(const std::vector<uint64_t>& detections) {
       }
       assert(*return_status == HighsStatus::kOk);
 
-      if (config.verbose) {
-        // Get the solution information
+      if (config.log_stream.active) {
         const HighsInfo& info = highs->getInfo();
-        std::cout << "Simplex iteration count: " << info.simplex_iteration_count << std::endl;
-        std::cout << "Objective function value: " << info.objective_function_value << std::endl;
-        std::cout << "Primal  solution status: "
-                  << highs->solutionStatusToString(info.primal_solution_status) << std::endl;
-        std::cout << "Dual    solution status: "
-                  << highs->solutionStatusToString(info.dual_solution_status) << std::endl;
-        std::cout << "Basis: " << highs->basisValidityToString(info.basis_validity) << std::endl;
+        config.log_stream << "Simplex iteration count: " << info.simplex_iteration_count
+                          << std::endl;
+        config.log_stream << "Objective function value: " << info.objective_function_value
+                          << std::endl;
+        config.log_stream << "Primal  solution status: "
+                          << highs->solutionStatusToString(info.primal_solution_status)
+                          << std::endl;
+        config.log_stream << "Dual    solution status: "
+                          << highs->solutionStatusToString(info.dual_solution_status)
+                          << std::endl;
+        config.log_stream << "Basis: "
+                           << highs->basisValidityToString(info.basis_validity) << std::endl;
       }
 
       // Get the model status
@@ -286,16 +304,20 @@ void SimplexDecoder::decode_to_errors(const std::vector<uint64_t>& detections) {
     *return_status = highs->run();
     assert(*return_status == HighsStatus::kOk);
 
-    if (config.verbose) {
-      // Get the solution information
+    if (config.log_stream.active) {
       const HighsInfo& info = highs->getInfo();
-      std::cout << "Simplex iteration count: " << info.simplex_iteration_count << std::endl;
-      std::cout << "Objective function value: " << info.objective_function_value << std::endl;
-      std::cout << "Primal  solution status: "
-                << highs->solutionStatusToString(info.primal_solution_status) << std::endl;
-      std::cout << "Dual    solution status: "
-                << highs->solutionStatusToString(info.dual_solution_status) << std::endl;
-      std::cout << "Basis: " << highs->basisValidityToString(info.basis_validity) << std::endl;
+      config.log_stream << "Simplex iteration count: " << info.simplex_iteration_count
+                        << std::endl;
+      config.log_stream << "Objective function value: " << info.objective_function_value
+                        << std::endl;
+      config.log_stream << "Primal  solution status: "
+                        << highs->solutionStatusToString(info.primal_solution_status)
+                        << std::endl;
+      config.log_stream << "Dual    solution status: "
+                        << highs->solutionStatusToString(info.dual_solution_status)
+                        << std::endl;
+      config.log_stream << "Basis: "
+                         << highs->basisValidityToString(info.basis_validity) << std::endl;
     }
 
     // Get the model status

--- a/src/simplex.h
+++ b/src/simplex.h
@@ -14,11 +14,13 @@
 
 #ifndef SIMPLEX_HPP
 #define SIMPLEX_HPP
+#include <functional>
 #include <unordered_set>
 #include <vector>
 
 #include "common.h"
 #include "stim.h"
+#include "utils.h"
 
 struct HighsModel;
 struct Highs;
@@ -29,7 +31,8 @@ struct SimplexConfig {
   bool parallelize = false;
   size_t window_length = 0;
   size_t window_slide_length = 0;
-  bool verbose = false;
+  std::function<void(const std::string&)> verbose_callback;
+  CallbackStream log_stream;
   bool windowing_enabled() {
     return (window_length != 0);
   }

--- a/src/simplex_main.cc
+++ b/src/simplex_main.cc
@@ -15,6 +15,7 @@
 #include <argparse/argparse.hpp>
 #include <atomic>
 #include <fstream>
+#include <iostream>
 #include <nlohmann/json.hpp>
 #include <thread>
 
@@ -134,6 +135,8 @@ struct Args {
 
   void extract(SimplexConfig& config, std::vector<stim::SparseShot>& shots,
                std::unique_ptr<stim::MeasureRecordWriter>& writer) {
+    config.verbose_callback = [](const std::string& s) { std::cout << s; };
+    config.log_stream = CallbackStream(verbose, config.verbose_callback);
     // Get a circuit, if available
     stim::Circuit circuit;
     if (!circuit_path.empty()) {
@@ -261,7 +264,8 @@ struct Args {
     config.parallelize = enable_ilp_solver_parallelism;
     config.window_length = window_length;
     config.window_slide_length = window_slide_length;
-    config.verbose = verbose;
+    config.log_stream.active = verbose;
+    config.log_stream.callback = config.verbose_callback;
   }
 };
 

--- a/src/tesseract.cc
+++ b/src/tesseract.cc
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <functional>  // For std::hash (though not strictly necessary here, but good practice)
 #include <iostream>
+#include <iostream>
 
 namespace {
 
@@ -58,7 +59,6 @@ std::string TesseractConfig::str() {
   ss << "det_beam=" << config.det_beam << ", ";
   ss << "no_revisit_dets=" << config.no_revisit_dets << ", ";
   ss << "at_most_two_errors_per_detector=" << config.at_most_two_errors_per_detector << ", ";
-  ss << "verbose=" << config.verbose << ", ";
   ss << "pqlimit=" << config.pqlimit << ", ";
   ss << "det_orders=" << config.det_orders << ", ";
   ss << "det_penalty=" << config.det_penalty << ")";
@@ -103,6 +103,10 @@ double TesseractDecoder::get_detcost(
 }
 
 TesseractDecoder::TesseractDecoder(TesseractConfig config_) : config(config_) {
+  if (!config.verbose_callback) {
+    config.verbose_callback = [](const std::string& s) { std::cout << s; };
+  }
+  config.log_stream.callback = config.verbose_callback;
   config.dem = common::remove_zero_probability_errors(config.dem);
   if (config.det_orders.empty()) {
     config.det_orders.emplace_back(config.dem.count_detectors());
@@ -114,10 +118,8 @@ TesseractDecoder::TesseractDecoder(TesseractConfig config_) : config(config_) {
   }
   assert(config.det_orders.size());
   errors = get_errors_from_dem(config.dem.flattened());
-  if (config.verbose) {
-    for (auto& error : errors) {
-      std::cout << error.str() << std::endl;
-    }
+  for (auto& error : errors) {
+    config.log_stream << error.str() << std::endl;
   }
   num_detectors = config.dem.count_detectors();
   num_errors = config.dem.count_errors();
@@ -181,12 +183,17 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections)
         best_errors = predicted_errors_buffer;
         best_cost = local_cost;
       }
-      if (config.verbose) {
-        std::cout << "for detector_order " << detector_order << " beam " << beam
-                  << " got low confidence " << low_confidence_flag << " and cost " << local_cost
-                  << " and obs_mask " << get_flipped_observables(predicted_errors_buffer)
-                  << ". Best cost so far: " << best_cost << std::endl;
+      auto obs_mask_vec = get_flipped_observables(predicted_errors_buffer);
+      config.log_stream << "for detector_order " << detector_order << " beam " << beam
+                        << " got low confidence " << low_confidence_flag << " and cost "
+                        << local_cost << " and obs_mask ";
+      config.log_stream << "[";
+      for (size_t i = 0; i < obs_mask_vec.size(); ++i) {
+        config.log_stream << obs_mask_vec[i];
+        if (i + 1 < obs_mask_vec.size()) config.log_stream << ", ";
       }
+      config.log_stream << "]";
+      config.log_stream << ". Best cost so far: " << best_cost << std::endl;
     }
   } else {
     for (size_t detector_order = 0; detector_order < config.det_orders.size(); ++detector_order) {
@@ -196,12 +203,17 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections)
         best_errors = predicted_errors_buffer;
         best_cost = local_cost;
       }
-      if (config.verbose) {
-        std::cout << "for detector_order " << detector_order << " beam " << config.det_beam
-                  << " got low confidence " << low_confidence_flag << " and cost " << local_cost
-                  << " and obs_mask " << get_flipped_observables(predicted_errors_buffer)
-                  << ". Best cost so far: " << best_cost << std::endl;
+      auto obs_mask_vec = get_flipped_observables(predicted_errors_buffer);
+      config.log_stream << "for detector_order " << detector_order << " beam " << config.det_beam
+                        << " got low confidence " << low_confidence_flag << " and cost "
+                        << local_cost << " and obs_mask ";
+      config.log_stream << "[";
+      for (size_t i = 0; i < obs_mask_vec.size(); ++i) {
+        config.log_stream << obs_mask_vec[i];
+        if (i + 1 < obs_mask_vec.size()) config.log_stream << ", ";
       }
+      config.log_stream << "]";
+      config.log_stream << ". Best cost so far: " << best_cost << std::endl;
     }
   }
   predicted_errors_buffer = best_errors;
@@ -285,23 +297,20 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
     flip_detectors_and_block_errors(detector_order, node.errors, detectors, detector_cost_tuples);
 
     if (node.num_detectors == 0) {
-      if (config.verbose) {
-        std::cout << "activated_errors = ";
-        for (size_t oei : node.errors) {
-          std::cout << oei << ", ";
-        }
-        std::cout << std::endl;
-        std::cout << "activated_detectors = ";
-        for (size_t d = 0; d < num_detectors; ++d) {
-          if (detectors[d]) {
-            std::cout << d << ", ";
-          }
-        }
-        std::cout << std::endl;
-        std::cout.precision(13);
-        std::cout << "Decoding complete. Cost: " << node.cost
-                  << " num_pq_pushed = " << num_pq_pushed << std::endl;
+      config.log_stream << "activated_errors = ";
+      for (size_t oei : node.errors) {
+        config.log_stream << oei << ", ";
       }
+      config.log_stream << std::endl;
+      config.log_stream << "activated_detectors = ";
+      for (size_t d = 0; d < num_detectors; ++d) {
+        if (detectors[d]) {
+          config.log_stream << d << ", ";
+        }
+      }
+      config.log_stream << std::endl;
+      config.log_stream << "Decoding complete. Cost: " << node.cost
+                        << " num_pq_pushed = " << num_pq_pushed << std::endl;
       predicted_errors_buffer = node.errors;
       return;
     }
@@ -309,25 +318,23 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
     if (config.no_revisit_dets && !visited_detectors[node.num_detectors].insert(detectors).second)
       continue;
 
-    if (config.verbose) {
-      std::cout.precision(13);
-      std::cout << "len(pq) = " << pq.size() << " num_pq_pushed = " << num_pq_pushed << std::endl;
-      std::cout << "num_detectors = " << node.num_detectors
-                << " max_num_detectors = " << max_num_detectors << " cost = " << node.cost
-                << std::endl;
-      std::cout << "activated_errors = ";
-      for (size_t oei : node.errors) {
-        std::cout << oei << ", ";
-      }
-      std::cout << std::endl;
-      std::cout << "activated_detectors = ";
-      for (size_t d = 0; d < num_detectors; ++d) {
-        if (detectors[d]) {
-          std::cout << d << ", ";
-        }
-      }
-      std::cout << std::endl;
+    config.log_stream << "len(pq) = " << pq.size() << " num_pq_pushed = " << num_pq_pushed
+                      << std::endl;
+    config.log_stream << "num_detectors = " << node.num_detectors
+                      << " max_num_detectors = " << max_num_detectors
+                      << " cost = " << node.cost << std::endl;
+    config.log_stream << "activated_errors = ";
+    for (size_t oei : node.errors) {
+      config.log_stream << oei << ", ";
     }
+    config.log_stream << std::endl;
+    config.log_stream << "activated_detectors = ";
+    for (size_t d = 0; d < num_detectors; ++d) {
+      if (detectors[d]) {
+        config.log_stream << d << ", ";
+      }
+    }
+    config.log_stream << std::endl;
 
     if (node.num_detectors < min_num_detectors) {
       min_num_detectors = node.num_detectors;
@@ -450,9 +457,7 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
   }
 
   assert(pq.empty());
-  if (config.verbose) {
-    std::cout << "Decoding failed to converge within beam limit." << std::endl;
-  }
+  config.log_stream << "Decoding failed to converge within beam limit." << std::endl;
   low_confidence_flag = true;
 }
 

--- a/src/tesseract.h
+++ b/src/tesseract.h
@@ -16,6 +16,7 @@
 #define TESSERACT_DECODER_H
 
 #include <boost/dynamic_bitset.hpp>
+#include <functional>
 #include <queue>
 #include <string>
 #include <unordered_map>
@@ -34,10 +35,11 @@ struct TesseractConfig {
   bool beam_climbing = false;
   bool no_revisit_dets = false;
   bool at_most_two_errors_per_detector = false;
-  bool verbose;
   size_t pqlimit = std::numeric_limits<size_t>::max();
   std::vector<std::vector<size_t>> det_orders;
   double det_penalty = 0;
+  std::function<void(const std::string&)> verbose_callback;
+  CallbackStream log_stream;
 
   std::string str();
 };

--- a/src/tesseract_main.cc
+++ b/src/tesseract_main.cc
@@ -16,6 +16,7 @@
 #include <argparse/argparse.hpp>
 #include <atomic>
 #include <fstream>
+#include <iostream>
 #include <nlohmann/json.hpp>
 #include <numeric>
 #include <queue>
@@ -134,6 +135,8 @@ struct Args {
 
   void extract(TesseractConfig& config, std::vector<stim::SparseShot>& shots,
                std::unique_ptr<stim::MeasureRecordWriter>& writer) {
+    config.verbose_callback = [](const std::string& s) { std::cout << s; };
+    config.log_stream = CallbackStream(verbose, config.verbose_callback);
     // Get a circuit, if available
     stim::Circuit circuit;
     if (!circuit_path.empty()) {
@@ -171,17 +174,15 @@ struct Args {
 
     // Sample orientations of the error model to use for the det priority
     {
-      if (verbose) {
-        auto detector_coords = get_detector_coords(config.dem);
-        for (size_t d = 0; d < detector_coords.size(); ++d) {
-          std::cout << "Detector D" << d << " coordinate (";
-          size_t e = std::min(3ul, detector_coords[d].size());
-          for (size_t i = 0; i < e; ++i) {
-            std::cout << detector_coords[d][i];
-            if (i + 1 < e) std::cout << ", ";
-          }
-          std::cout << ")" << std::endl;
+      auto detector_coords = get_detector_coords(config.dem);
+      for (size_t d = 0; d < detector_coords.size(); ++d) {
+        config.log_stream << "Detector D" << d << " coordinate (";
+        size_t e = std::min(3ul, detector_coords[d].size());
+        for (size_t i = 0; i < e; ++i) {
+          config.log_stream << detector_coords[d][i];
+          if (i + 1 < e) config.log_stream << ", ";
         }
+        config.log_stream << ")" << std::endl;
       }
       config.det_orders =
           build_det_orders(config.dem, num_det_orders, det_order_bfs, det_order_seed);
@@ -281,7 +282,8 @@ struct Args {
     config.no_revisit_dets = no_revisit_dets;
     config.at_most_two_errors_per_detector = at_most_two_errors_per_detector;
     config.pqlimit = pqlimit;
-    config.verbose = verbose;
+    config.log_stream.active = verbose;
+    config.log_stream.callback = config.verbose_callback;
   }
 };
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,7 +18,9 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
+#include <functional>
 #include <random>
+#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -51,5 +53,54 @@ std::vector<common::Error> get_errors_from_dem(const stim::DetectorErrorModel& d
 std::vector<std::string> get_files_recursive(const std::string& directory_path);
 
 uint64_t vector_to_u64_mask(const std::vector<int>& v);
+
+struct CallbackStream {
+  bool active = false;
+  std::function<void(const std::string&)> callback;
+  std::stringstream buffer;
+
+  CallbackStream() = default;
+  CallbackStream(bool active_, std::function<void(const std::string&)> cb)
+      : active(active_), callback(std::move(cb)) {}
+
+  CallbackStream(const CallbackStream& other)
+      : active(other.active), callback(other.callback) {}
+  CallbackStream& operator=(const CallbackStream& other) {
+    active = other.active;
+    callback = other.callback;
+    buffer.str("");
+    buffer.clear();
+    return *this;
+  }
+  CallbackStream(CallbackStream&&) = default;
+  CallbackStream& operator=(CallbackStream&&) = default;
+
+  template <typename T>
+  CallbackStream& operator<<(const T& value) {
+    if (active) buffer << value;
+    return *this;
+  }
+
+  CallbackStream& operator<<(std::ostream& (*manip)(std::ostream&)) {
+    if (active) {
+      manip(buffer);
+      if (manip == static_cast<std::ostream& (*)(std::ostream&)>(std::endl) ||
+          manip == static_cast<std::ostream& (*)(std::ostream&)>(std::flush)) {
+        flush();
+      }
+    }
+    return *this;
+  }
+
+  void flush() {
+    if (active && callback && buffer.tellp() > 0) {
+      callback(buffer.str());
+      buffer.str("");
+      buffer.clear();
+    }
+  }
+
+  ~CallbackStream() { flush(); }
+};
 
 #endif  // __TESSERACT_UTILS_H__


### PR DESCRIPTION
## Summary
- remove redundant `verbose` flag; rely on `log_stream.active` for verbose output
- infer verbosity from callback presence in pybind config makers
- adjust tests to use callback-only configuration and direct imports

## Testing
- `cmake --build build -j 8`
- `PYTHONPATH=/workspace/tesseract-decoder/build pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892f528889883208545455b9d9a3748