### PR TITLE
Revert verbose logging refactor

### DIFF
--- a/src/py/simplex_test.py
+++ b/src/py/simplex_test.py
@@ -33,7 +33,7 @@ def test_create_simplex_config():
     assert sc.window_length == 5
     assert (
         str(sc)
-        == "SimplexConfig(dem=DetectorErrorModel_Object, window_length=5, window_slide_length=0)"
+        == "SimplexConfig(dem=DetectorErrorModel_Object, window_length=5, window_slide_length=0, verbose=0)"
     )
 
 
@@ -45,20 +45,6 @@ def test_create_simplex_decoder():
     assert decoder.get_observables_from_errors([1]) == []
     assert decoder.cost_from_errors([2]) == pytest.approx(1.0986123)
     assert decoder.decode([1]) == []
-
-
-def test_simplex_verbose_callback_receives_output():
-    lines = []
-
-    def cb(s: str) -> None:
-        lines.append(s)
-
-    config = tesseract_decoder.simplex.SimplexConfig(
-        _DETECTOR_ERROR_MODEL, window_length=5, verbose_callback=cb
-    )
-    decoder = tesseract_decoder.simplex.SimplexDecoder(config)
-    decoder.decode_to_errors([1])
-    assert any(lines)
 
 def test_simplex_decoder_predicts_various_observable_flips():
     """

--- a/src/py/tesseract_test.py
+++ b/src/py/tesseract_test.py
@@ -30,7 +30,7 @@ error(0.25) D1
 def test_create_config():
     assert (
         str(tesseract_decoder.tesseract.TesseractConfig(_DETECTOR_ERROR_MODEL))
-        == "TesseractConfig(dem=DetectorErrorModel_Object, det_beam=65535, no_revisit_dets=0, at_most_two_errors_per_detector=0, pqlimit=18446744073709551615, det_orders=[], det_penalty=0)"
+        == "TesseractConfig(dem=DetectorErrorModel_Object, det_beam=65535, no_revisit_dets=0, at_most_two_errors_per_detector=0, verbose=0, pqlimit=18446744073709551615, det_orders=[], det_penalty=0)"
     )
     assert (
         tesseract_decoder.tesseract.TesseractConfig(_DETECTOR_ERROR_MODEL).dem
@@ -51,20 +51,6 @@ def test_create_decoder():
     assert decoder.get_observables_from_errors([1]) == []
     assert decoder.cost_from_errors([1]) == pytest.approx(0.5108256237659907)
     assert decoder.decode([0]) == []
-
-
-def test_tesseract_verbose_callback_receives_output():
-    lines = []
-
-    def cb(s: str) -> None:
-        lines.append(s)
-
-    config = tesseract_decoder.tesseract.TesseractConfig(
-        _DETECTOR_ERROR_MODEL, verbose_callback=cb
-    )
-    decoder = tesseract_decoder.tesseract.TesseractDecoder(config)
-    decoder.decode_to_errors([0])
-    assert any(lines)
 
 def test_tesseract_decoder_predicts_various_observable_flips():
     """

--- a/src/simplex.h
+++ b/src/simplex.h
@@ -14,13 +14,11 @@
 
 #ifndef SIMPLEX_HPP
 #define SIMPLEX_HPP
-#include <functional>
 #include <unordered_set>
 #include <vector>
 
 #include "common.h"
 #include "stim.h"
-#include "utils.h"
 
 struct HighsModel;
 struct Highs;
@@ -31,8 +29,7 @@ struct SimplexConfig {
   bool parallelize = false;
   size_t window_length = 0;
   size_t window_slide_length = 0;
-  std::function<void(const std::string&)> verbose_callback;
-  CallbackStream log_stream;
+  bool verbose = false;
   bool windowing_enabled() {
     return (window_length != 0);
   }

--- a/src/simplex.pybind.h
+++ b/src/simplex.pybind.h
@@ -19,8 +19,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <iostream>
-
 #include "common.h"
 #include "simplex.h"
 #include "stim_utils.pybind.h"
@@ -30,26 +28,9 @@ namespace py = pybind11;
 namespace {
 SimplexConfig simplex_config_maker(py::object dem, bool parallelize = false,
                                    size_t window_length = 0, size_t window_slide_length = 0,
-                                   py::object verbose_callback = py::none()) {
+                                   bool verbose = false) {
   stim::DetectorErrorModel input_dem = parse_py_object<stim::DetectorErrorModel>(dem);
-  SimplexConfig cfg;
-  cfg.dem = input_dem;
-  cfg.parallelize = parallelize;
-  cfg.window_length = window_length;
-  cfg.window_slide_length = window_slide_length;
-  std::function<void(const std::string&)> cb;
-  bool active = false;
-  if (!verbose_callback.is_none()) {
-    py::function f = verbose_callback;
-    cb = [f](const std::string& s) {
-      py::gil_scoped_acquire gil;
-      f(s);
-    };
-    active = true;
-  }
-  cfg.verbose_callback = cb;
-  cfg.log_stream = CallbackStream(active, cfg.verbose_callback);
-  return cfg;
+  return SimplexConfig({input_dem, parallelize, window_length, window_slide_length, verbose});
 }
 
 };  // namespace
@@ -61,11 +42,12 @@ void add_simplex_module(py::module& root) {
   py::class_<SimplexConfig>(m, "SimplexConfig")
       .def(py::init(&simplex_config_maker), py::arg("dem"), py::arg("parallelize") = false,
            py::arg("window_length") = 0, py::arg("window_slide_length") = 0,
-           py::arg("verbose_callback") = py::none())
+           py::arg("verbose") = false)
       .def_property("dem", &dem_getter<SimplexConfig>, &dem_setter<SimplexConfig>)
       .def_readwrite("parallelize", &SimplexConfig::parallelize)
       .def_readwrite("window_length", &SimplexConfig::window_length)
       .def_readwrite("window_slide_length", &SimplexConfig::window_slide_length)
+      .def_readwrite("verbose", &SimplexConfig::verbose)
       .def("windowing_enabled", &SimplexConfig::windowing_enabled)
       .def("__str__", &SimplexConfig::str);
 

--- a/src/simplex_main.cc
+++ b/src/simplex_main.cc
@@ -15,7 +15,6 @@
 #include <argparse/argparse.hpp>
 #include <atomic>
 #include <fstream>
-#include <iostream>
 #include <nlohmann/json.hpp>
 #include <thread>
 
@@ -135,8 +134,6 @@ struct Args {
 
   void extract(SimplexConfig& config, std::vector<stim::SparseShot>& shots,
                std::unique_ptr<stim::MeasureRecordWriter>& writer) {
-    config.verbose_callback = [](const std::string& s) { std::cout << s; };
-    config.log_stream = CallbackStream(verbose, config.verbose_callback);
     // Get a circuit, if available
     stim::Circuit circuit;
     if (!circuit_path.empty()) {
@@ -264,8 +261,7 @@ struct Args {
     config.parallelize = enable_ilp_solver_parallelism;
     config.window_length = window_length;
     config.window_slide_length = window_slide_length;
-    config.log_stream.active = verbose;
-    config.log_stream.callback = config.verbose_callback;
+    config.verbose = verbose;
   }
 };
 

--- a/src/tesseract.cc
+++ b/src/tesseract.cc
@@ -58,6 +58,7 @@ std::string TesseractConfig::str() {
   ss << "det_beam=" << config.det_beam << ", ";
   ss << "no_revisit_dets=" << config.no_revisit_dets << ", ";
   ss << "at_most_two_errors_per_detector=" << config.at_most_two_errors_per_detector << ", ";
+  ss << "verbose=" << config.verbose << ", ";
   ss << "pqlimit=" << config.pqlimit << ", ";
   ss << "det_orders=" << config.det_orders << ", ";
   ss << "det_penalty=" << config.det_penalty << ")";
@@ -102,10 +103,6 @@ double TesseractDecoder::get_detcost(
 }
 
 TesseractDecoder::TesseractDecoder(TesseractConfig config_) : config(config_) {
-  if (!config.verbose_callback) {
-    config.verbose_callback = [](const std::string& s) { std::cout << s; };
-  }
-  config.log_stream.callback = config.verbose_callback;
   config.dem = common::remove_zero_probability_errors(config.dem);
   if (config.det_orders.empty()) {
     config.det_orders.emplace_back(config.dem.count_detectors());
@@ -117,8 +114,10 @@ TesseractDecoder::TesseractDecoder(TesseractConfig config_) : config(config_) {
   }
   assert(config.det_orders.size());
   errors = get_errors_from_dem(config.dem.flattened());
-  for (auto& error : errors) {
-    config.log_stream << error.str() << std::endl;
+  if (config.verbose) {
+    for (auto& error : errors) {
+      std::cout << error.str() << std::endl;
+    }
   }
   num_detectors = config.dem.count_detectors();
   num_errors = config.dem.count_errors();
@@ -182,17 +181,12 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections)
         best_errors = predicted_errors_buffer;
         best_cost = local_cost;
       }
-      auto obs_mask_vec = get_flipped_observables(predicted_errors_buffer);
-      config.log_stream << "for detector_order " << detector_order << " beam " << beam
-                        << " got low confidence " << low_confidence_flag << " and cost "
-                        << local_cost << " and obs_mask ";
-      config.log_stream << "[";
-      for (size_t i = 0; i < obs_mask_vec.size(); ++i) {
-        config.log_stream << obs_mask_vec[i];
-        if (i + 1 < obs_mask_vec.size()) config.log_stream << ", ";
+      if (config.verbose) {
+        std::cout << "for detector_order " << detector_order << " beam " << beam
+                  << " got low confidence " << low_confidence_flag << " and cost " << local_cost
+                  << " and obs_mask " << get_flipped_observables(predicted_errors_buffer)
+                  << ". Best cost so far: " << best_cost << std::endl;
       }
-      config.log_stream << "]";
-      config.log_stream << ". Best cost so far: " << best_cost << std::endl;
     }
   } else {
     for (size_t detector_order = 0; detector_order < config.det_orders.size(); ++detector_order) {
@@ -202,17 +196,12 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections)
         best_errors = predicted_errors_buffer;
         best_cost = local_cost;
       }
-      auto obs_mask_vec = get_flipped_observables(predicted_errors_buffer);
-      config.log_stream << "for detector_order " << detector_order << " beam " << config.det_beam
-                        << " got low confidence " << low_confidence_flag << " and cost "
-                        << local_cost << " and obs_mask ";
-      config.log_stream << "[";
-      for (size_t i = 0; i < obs_mask_vec.size(); ++i) {
-        config.log_stream << obs_mask_vec[i];
-        if (i + 1 < obs_mask_vec.size()) config.log_stream << ", ";
+      if (config.verbose) {
+        std::cout << "for detector_order " << detector_order << " beam " << config.det_beam
+                  << " got low confidence " << low_confidence_flag << " and cost " << local_cost
+                  << " and obs_mask " << get_flipped_observables(predicted_errors_buffer)
+                  << ". Best cost so far: " << best_cost << std::endl;
       }
-      config.log_stream << "]";
-      config.log_stream << ". Best cost so far: " << best_cost << std::endl;
     }
   }
   predicted_errors_buffer = best_errors;
@@ -296,20 +285,23 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
     flip_detectors_and_block_errors(detector_order, node.errors, detectors, detector_cost_tuples);
 
     if (node.num_detectors == 0) {
-      config.log_stream << "activated_errors = ";
-      for (size_t oei : node.errors) {
-        config.log_stream << oei << ", ";
-      }
-      config.log_stream << std::endl;
-      config.log_stream << "activated_detectors = ";
-      for (size_t d = 0; d < num_detectors; ++d) {
-        if (detectors[d]) {
-          config.log_stream << d << ", ";
+      if (config.verbose) {
+        std::cout << "activated_errors = ";
+        for (size_t oei : node.errors) {
+          std::cout << oei << ", ";
         }
+        std::cout << std::endl;
+        std::cout << "activated_detectors = ";
+        for (size_t d = 0; d < num_detectors; ++d) {
+          if (detectors[d]) {
+            std::cout << d << ", ";
+          }
+        }
+        std::cout << std::endl;
+        std::cout.precision(13);
+        std::cout << "Decoding complete. Cost: " << node.cost
+                  << " num_pq_pushed = " << num_pq_pushed << std::endl;
       }
-      config.log_stream << std::endl;
-      config.log_stream << "Decoding complete. Cost: " << node.cost
-                        << " num_pq_pushed = " << num_pq_pushed << std::endl;
       predicted_errors_buffer = node.errors;
       return;
     }
@@ -317,23 +309,25 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
     if (config.no_revisit_dets && !visited_detectors[node.num_detectors].insert(detectors).second)
       continue;
 
-    config.log_stream << "len(pq) = " << pq.size() << " num_pq_pushed = " << num_pq_pushed
-                      << std::endl;
-    config.log_stream << "num_detectors = " << node.num_detectors
-                      << " max_num_detectors = " << max_num_detectors << " cost = " << node.cost
-                      << std::endl;
-    config.log_stream << "activated_errors = ";
-    for (size_t oei : node.errors) {
-      config.log_stream << oei << ", ";
-    }
-    config.log_stream << std::endl;
-    config.log_stream << "activated_detectors = ";
-    for (size_t d = 0; d < num_detectors; ++d) {
-      if (detectors[d]) {
-        config.log_stream << d << ", ";
+    if (config.verbose) {
+      std::cout.precision(13);
+      std::cout << "len(pq) = " << pq.size() << " num_pq_pushed = " << num_pq_pushed << std::endl;
+      std::cout << "num_detectors = " << node.num_detectors
+                << " max_num_detectors = " << max_num_detectors << " cost = " << node.cost
+                << std::endl;
+      std::cout << "activated_errors = ";
+      for (size_t oei : node.errors) {
+        std::cout << oei << ", ";
+        }
+      std::cout << std::endl;
+      std::cout << "activated_detectors = ";
+      for (size_t d = 0; d < num_detectors; ++d) {
+        if (detectors[d]) {
+          std::cout << d << ", ";
+        }
       }
+      std::cout << std::endl;
     }
-    config.log_stream << std::endl;
 
     if (node.num_detectors < min_num_detectors) {
       min_num_detectors = node.num_detectors;
@@ -456,7 +450,9 @@ void TesseractDecoder::decode_to_errors(const std::vector<uint64_t>& detections,
   }
 
   assert(pq.empty());
-  config.log_stream << "Decoding failed to converge within beam limit." << std::endl;
+  if (config.verbose) {
+    std::cout << "Decoding failed to converge within beam limit." << std::endl;
+  }
   low_confidence_flag = true;
 }
 

--- a/src/tesseract.h
+++ b/src/tesseract.h
@@ -16,7 +16,6 @@
 #define TESSERACT_DECODER_H
 
 #include <boost/dynamic_bitset.hpp>
-#include <functional>
 #include <queue>
 #include <string>
 #include <unordered_map>
@@ -35,11 +34,10 @@ struct TesseractConfig {
   bool beam_climbing = false;
   bool no_revisit_dets = false;
   bool at_most_two_errors_per_detector = false;
+  bool verbose;
   size_t pqlimit = std::numeric_limits<size_t>::max();
   std::vector<std::vector<size_t>> det_orders;
   double det_penalty = 0;
-  std::function<void(const std::string&)> verbose_callback;
-  CallbackStream log_stream;
 
   std::string str();
 };

--- a/src/tesseract.pybind.h
+++ b/src/tesseract.pybind.h
@@ -19,8 +19,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include <iostream>
-
 #include "stim_utils.pybind.h"
 #include "tesseract.h"
 
@@ -30,32 +28,13 @@ namespace {
 TesseractConfig tesseract_config_maker(
     py::object dem, int det_beam = INF_DET_BEAM, bool beam_climbing = false,
     bool no_revisit_dets = false, bool at_most_two_errors_per_detector = false,
-    size_t pqlimit = std::numeric_limits<size_t>::max(),
+    bool verbose = false, size_t pqlimit = std::numeric_limits<size_t>::max(),
     std::vector<std::vector<size_t>> det_orders = std::vector<std::vector<size_t>>(),
-    double det_penalty = 0.0, py::object verbose_callback = py::none()) {
+    double det_penalty = 0.0) {
   stim::DetectorErrorModel input_dem = parse_py_object<stim::DetectorErrorModel>(dem);
-  TesseractConfig cfg;
-  cfg.dem = input_dem;
-  cfg.det_beam = det_beam;
-  cfg.beam_climbing = beam_climbing;
-  cfg.no_revisit_dets = no_revisit_dets;
-  cfg.at_most_two_errors_per_detector = at_most_two_errors_per_detector;
-  cfg.pqlimit = pqlimit;
-  cfg.det_orders = det_orders;
-  cfg.det_penalty = det_penalty;
-  std::function<void(const std::string&)> cb;
-  bool active = false;
-  if (!verbose_callback.is_none()) {
-    py::function f = verbose_callback;
-    cb = [f](const std::string& s) {
-      py::gil_scoped_acquire gil;
-      f(s);
-    };
-    active = true;
-  }
-  cfg.verbose_callback = cb;
-  cfg.log_stream = CallbackStream(active, cfg.verbose_callback);
-  return cfg;
+  return TesseractConfig({input_dem, det_beam, beam_climbing, no_revisit_dets,
+                          at_most_two_errors_per_detector, verbose, pqlimit, det_orders,
+                          det_penalty});
 }
 };  // namespace
 void add_tesseract_module(py::module& root) {
@@ -65,15 +44,15 @@ void add_tesseract_module(py::module& root) {
   py::class_<TesseractConfig>(m, "TesseractConfig")
       .def(py::init(&tesseract_config_maker), py::arg("dem"), py::arg("det_beam") = INF_DET_BEAM,
            py::arg("beam_climbing") = false, py::arg("no_revisit_dets") = false,
-           py::arg("at_most_two_errors_per_detector") = false,
+           py::arg("at_most_two_errors_per_detector") = false, py::arg("verbose") = false,
            py::arg("pqlimit") = std::numeric_limits<size_t>::max(),
-           py::arg("det_orders") = std::vector<std::vector<size_t>>(), py::arg("det_penalty") = 0.0,
-           py::arg("verbose_callback") = py::none())
+             py::arg("det_orders") = std::vector<std::vector<size_t>>(), py::arg("det_penalty") = 0.0)
       .def_property("dem", &dem_getter<TesseractConfig>, &dem_setter<TesseractConfig>)
       .def_readwrite("det_beam", &TesseractConfig::det_beam)
       .def_readwrite("no_revisit_dets", &TesseractConfig::no_revisit_dets)
       .def_readwrite("at_most_two_errors_per_detector",
                      &TesseractConfig::at_most_two_errors_per_detector)
+      .def_readwrite("verbose", &TesseractConfig::verbose)
       .def_readwrite("pqlimit", &TesseractConfig::pqlimit)
       .def_readwrite("det_orders", &TesseractConfig::det_orders)
       .def_readwrite("det_penalty", &TesseractConfig::det_penalty)

--- a/src/tesseract_main.cc
+++ b/src/tesseract_main.cc
@@ -16,7 +16,6 @@
 #include <argparse/argparse.hpp>
 #include <atomic>
 #include <fstream>
-#include <iostream>
 #include <nlohmann/json.hpp>
 #include <numeric>
 #include <queue>
@@ -135,8 +134,6 @@ struct Args {
 
   void extract(TesseractConfig& config, std::vector<stim::SparseShot>& shots,
                std::unique_ptr<stim::MeasureRecordWriter>& writer) {
-    config.verbose_callback = [](const std::string& s) { std::cout << s; };
-    config.log_stream = CallbackStream(verbose, config.verbose_callback);
     // Get a circuit, if available
     stim::Circuit circuit;
     if (!circuit_path.empty()) {
@@ -174,15 +171,17 @@ struct Args {
 
     // Sample orientations of the error model to use for the det priority
     {
-      auto detector_coords = get_detector_coords(config.dem);
-      for (size_t d = 0; d < detector_coords.size(); ++d) {
-        config.log_stream << "Detector D" << d << " coordinate (";
-        size_t e = std::min(3ul, detector_coords[d].size());
-        for (size_t i = 0; i < e; ++i) {
-          config.log_stream << detector_coords[d][i];
-          if (i + 1 < e) config.log_stream << ", ";
+      if (verbose) {
+        auto detector_coords = get_detector_coords(config.dem);
+        for (size_t d = 0; d < detector_coords.size(); ++d) {
+          std::cout << "Detector D" << d << " coordinate (";
+          size_t e = std::min(3ul, detector_coords[d].size());
+          for (size_t i = 0; i < e; ++i) {
+            std::cout << detector_coords[d][i];
+            if (i + 1 < e) std::cout << ", ";
+          }
+          std::cout << ")" << std::endl;
         }
-        config.log_stream << ")" << std::endl;
       }
       config.det_orders =
           build_det_orders(config.dem, num_det_orders, det_order_bfs, det_order_seed);
@@ -282,8 +281,7 @@ struct Args {
     config.no_revisit_dets = no_revisit_dets;
     config.at_most_two_errors_per_detector = at_most_two_errors_per_detector;
     config.pqlimit = pqlimit;
-    config.log_stream.active = verbose;
-    config.log_stream.callback = config.verbose_callback;
+    config.verbose = verbose;
   }
 };
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,9 +18,7 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
-#include <functional>
 #include <random>
-#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -53,55 +51,4 @@ std::vector<common::Error> get_errors_from_dem(const stim::DetectorErrorModel& d
 std::vector<std::string> get_files_recursive(const std::string& directory_path);
 
 uint64_t vector_to_u64_mask(const std::vector<int>& v);
-
-struct CallbackStream {
-  bool active = false;
-  std::function<void(const std::string&)> callback;
-  std::stringstream buffer;
-
-  CallbackStream() = default;
-  CallbackStream(bool active_, std::function<void(const std::string&)> cb)
-      : active(active_), callback(std::move(cb)) {}
-
-  CallbackStream(const CallbackStream& other) : active(other.active), callback(other.callback) {}
-  CallbackStream& operator=(const CallbackStream& other) {
-    active = other.active;
-    callback = other.callback;
-    buffer.str("");
-    buffer.clear();
-    return *this;
-  }
-  CallbackStream(CallbackStream&&) = default;
-  CallbackStream& operator=(CallbackStream&&) = default;
-
-  template <typename T>
-  CallbackStream& operator<<(const T& value) {
-    if (active) buffer << value;
-    return *this;
-  }
-
-  CallbackStream& operator<<(std::ostream& (*manip)(std::ostream&)) {
-    if (active) {
-      manip(buffer);
-      if (manip == static_cast<std::ostream& (*)(std::ostream&)>(std::endl) ||
-          manip == static_cast<std::ostream& (*)(std::ostream&)>(std::flush)) {
-        flush();
-      }
-    }
-    return *this;
-  }
-
-  void flush() {
-    if (active && callback && buffer.tellp() > 0) {
-      callback(buffer.str());
-      buffer.str("");
-      buffer.clear();
-    }
-  }
-
-  ~CallbackStream() {
-    flush();
-  }
-};
-
 #endif  // __TESSERACT_UTILS_H__


### PR DESCRIPTION
## Summary
- restore `verbose` flag logging in Simplex and Tesseract decoders
- drop CallbackStream-based log stream and related pybind hooks
- adjust bindings and tests to the verbose flag interface

## Testing
- `bazel test //src:all` *(fails: certificate_unknown: unable to find valid certification path to requested target)*

------
https://chatgpt.com/codex/tasks/task_e_6894f186adc88320bf92a4a95af03e77