### PR TITLE
Fix CMake Python module path and add agent build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ eclipse-*bin/
 /.sass-cache
 # User-specific .bazelrc
 user.bazelrc
+ 
+# Ignore python extension module produced by CMake.
+src/tesseract_decoder*.so

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions
+
+- Use the **CMake** build system when interacting with this repository. Humans use Bazel.
+- A bug in some LLM coding environments makes Bazel difficult to use, so agents should rely on CMake.
+- Keep both the CMake and Bazel builds working at all times.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,4 +103,11 @@ pybind11_add_module(tesseract_decoder MODULE ${TESSERACT_SRC_DIR}/tesseract.pybi
 target_compile_options(tesseract_decoder PRIVATE ${OPT_COPTS})
 target_include_directories(tesseract_decoder PRIVATE ${TESSERACT_SRC_DIR})
 target_link_libraries(tesseract_decoder PRIVATE common utils simplex tesseract_lib)
+set_target_properties(tesseract_decoder PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/src
+    LIBRARY_OUTPUT_DIRECTORY_DEBUG ${PROJECT_SOURCE_DIR}/src
+    LIBRARY_OUTPUT_DIRECTORY_RELEASE ${PROJECT_SOURCE_DIR}/src
+    LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL ${PROJECT_SOURCE_DIR}/src
+    LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO ${PROJECT_SOURCE_DIR}/src
+)
 


### PR DESCRIPTION
## Summary
- direct tesseract_decoder Python module to build into `src` so tests can import it
- ignore generated extension module in version control
- add agent instructions about preferring the CMake build

## Testing
- `pip install -r src/py/requirements.in`
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `PYTHONPATH=. pytest -q src/py --import-mode=importlib` *(fails: For observable L1: Expected predicted logical flips: [1], but got: [] (from raw: [False False]))*

------
https://chatgpt.com/codex/tasks/task_e_689c8435151483209036f9812491370f