### PR TITLE
Allow decode_to_errors to accept bitstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,15 +190,15 @@ config = tesseract.TesseractConfig(dem=dem, det_beam=50)
 # 3. Create a decoder instance
 decoder = config.compile_decoder()
 
-# 4. Simulate detection events
-syndrome = [0, 1, 1]
+# 4. Simulate detector outcomes
+syndrome = np.array([0, 1, 1], dtype=bool)
 
 # 5a. Decode to observables
 flipped_observables = decoder.decode(syndrome)
 print(f"Flipped observables: {flipped_observables}")
 
 # 5b. Alternatively, decode to errors
-decoder.decode_to_errors(np.where(syndrome)[0])
+decoder.decode_to_errors(syndrome)
 predicted_errors = decoder.predicted_errors_buffer
 # Indices of predicted errors
 print(f"Predicted errors indices: {predicted_errors}")

--- a/src/py/README.md
+++ b/src/py/README.md
@@ -64,28 +64,28 @@ print(f"Custom configuration detection penalty: {config2.det_beam}")
 #### Class `tesseract.TesseractDecoder`
 This is the main class that implements the Tesseract decoding logic.
 * `TesseractDecoder(config: tesseract.TesseractConfig)`
-* `decode_to_errors(detections: list[int])`
-* `decode_to_errors(detections: list[int], det_order: int, det_beam: int)`
+* `decode_to_errors(syndrome: np.ndarray)`
+* `decode_to_errors(syndrome: np.ndarray, det_order: int, det_beam: int)`
 * `get_observables_from_errors(predicted_errors: list[int]) -> list[bool]`
 * `cost_from_errors(predicted_errors: list[int]) -> float`
-* `decode(detections: list[int]) -> list[bool]`
+* `decode(syndrome: np.ndarray) -> np.ndarray`
 
 Explanation of each method:
-#### `decode_to_errors(detections: list[int])`
+#### `decode_to_errors(syndrome: np.ndarray)`
 
 Decodes a single measurement shot to predict a list of errors.
 
-* **Parameters:** `detections` is a list of integers that represent the indices of the detectors that have fired in a single shot.
+* **Parameters:** `syndrome` is a 1D NumPy array of booleans representing the detector outcomes for a single shot.
 
 * **Returns:** A list of integers, where each integer is the index of a predicted error.
 
-#### `decode_to_errors(detections: list[int], det_order: int, det_beam: int)`
+#### `decode_to_errors(syndrome: np.ndarray, det_order: int, det_beam: int)`
 
 An overloaded version of the `decode_to_errors` method that allows for a different decoding strategy.
 
 * **Parameters:**
 
-  * `detections` is a list of integers representing the indices of the fired detectors.
+  * `syndrome` is a 1D NumPy array of booleans representing the detector outcomes for a single shot.
 
   * `det_order` is an integer that specifies a different ordering of detectors to use for the decoding.
 
@@ -219,10 +219,10 @@ print(f"Configuration verbose enabled: {config.verbose}")
 This is the main class for performing decoding using the Simplex algorithm.
 * `SimplexDecoder(config: simplex.SimplexConfig)`
 * `init_ilp()`
-* `decode_to_errors(detections: list[int])`
+* `decode_to_errors(syndrome: np.ndarray)`
 * `get_observables_from_errors(predicted_errors: list[int]) -> list[bool]`
 * `cost_from_errors(predicted_errors: list[int]) -> float`
-* `decode(detections: list[int]) -> list[bool]`
+* `decode(syndrome: np.ndarray) -> np.ndarray`
 
 **Example Usage**:
 
@@ -230,6 +230,7 @@ This is the main class for performing decoding using the Simplex algorithm.
 import tesseract_decoder.simplex as simplex
 import stim
 import tesseract_decoder.common as common
+import numpy as np
 
 # Create a DEM and a configuration
 dem = stim.DetectorErrorModel("""
@@ -245,9 +246,9 @@ decoder = simplex.SimplexDecoder(config)
 decoder.init_ilp()
 
 # Decode a shot where detector D1 fired
-detections = [1]
-flipped_observables = decoder.decode(detections)
-print(f"Flipped observables for detections {detections}: {flipped_observables}")
+syndrome = np.array([0, 1], dtype=bool)
+flipped_observables = decoder.decode(syndrome)
+print(f"Flipped observables for syndrome {syndrome.tolist()}: {flipped_observables}")
 
 # Access predicted errors
 predicted_error_indices = decoder.predicted_errors_buffer

--- a/src/py/shared_decoding_tests.py
+++ b/src/py/shared_decoding_tests.py
@@ -302,16 +302,16 @@ def shared_test_merge_errors_affects_cost(decoder_class, config_class):
         error(0.01) D0
         """
     )
-    detections = [0]
+    syndrome = np.array([True], dtype=bool)
     
     config_no_merge = config_class(dem, merge_errors=False)
     decoder_no_merge = decoder_class(config_no_merge)
-    predicted_errors_no_merge = decoder_no_merge.decode_to_errors(detections)
+    predicted_errors_no_merge = decoder_no_merge.decode_to_errors(syndrome)
     cost_no_merge = decoder_no_merge.cost_from_errors(decoder_no_merge.predicted_errors_buffer)
         
     config_merge = config_class(dem, merge_errors=True)
     decoder_merge = decoder_class(config_merge)
-    predicted_errors_merge = decoder_merge.decode_to_errors(detections)
+    predicted_errors_merge = decoder_merge.decode_to_errors(syndrome)
     cost_merge = decoder_merge.cost_from_errors(decoder_merge.predicted_errors_buffer)
     
     p_merged = 0.1 * (1 - 0.01) + 0.01 * (1 - 0.1)

--- a/src/py/simplex_test.py
+++ b/src/py/simplex_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+import numpy as np
 import stim
 
 from src import tesseract_decoder
@@ -56,7 +57,7 @@ def test_create_simplex_decoder():
     decoder = tesseract_decoder.simplex.SimplexDecoder(
         tesseract_decoder.simplex.SimplexConfig(_DETECTOR_ERROR_MODEL, window_length=5)
     )
-    decoder.decode_to_errors([1])
+    decoder.decode_to_errors(np.array([False, True], dtype=bool))
     assert decoder.get_observables_from_errors([1]) == []
     assert decoder.cost_from_errors([2]) == pytest.approx(1.0986123)
 

--- a/src/py/tesseract_test.py
+++ b/src/py/tesseract_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+import numpy as np
 import stim
 
 from src import tesseract_decoder
@@ -60,8 +61,10 @@ def test_create_tesseract_config():
 def test_create_tesseract_decoder():
     config = tesseract_decoder.tesseract.TesseractConfig(_DETECTOR_ERROR_MODEL)
     decoder = tesseract_decoder.tesseract.TesseractDecoder(config)
-    decoder.decode_to_errors([0])
-    decoder.decode_to_errors(detections=[0], det_order=0, det_beam=0)
+    decoder.decode_to_errors(np.array([True, False], dtype=bool))
+    decoder.decode_to_errors(
+        syndrome=np.array([True, False], dtype=bool), det_order=0, det_beam=0
+    )
     assert decoder.get_observables_from_errors([1]) == []
     assert decoder.cost_from_errors([1]) == pytest.approx(0.5108256237659907)
 

--- a/src/simplex.pybind.h
+++ b/src/simplex.pybind.h
@@ -20,6 +20,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <sstream>
 
 #include "common.h"
 #include "simplex.h"
@@ -140,20 +141,43 @@ void add_simplex_module(py::module& root) {
 
         This method must be called before decoding.
       )pbdoc")
-      .def("decode_to_errors", &SimplexDecoder::decode_to_errors, py::arg("detections"),
-           py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>(), R"pbdoc(
+      .def(
+          "decode_to_errors",
+          [](SimplexDecoder& self, const py::array_t<bool>& syndrome) {
+            if ((size_t)syndrome.size() != self.num_detectors) {
+              std::ostringstream msg;
+              msg << "Syndrome array size (" << syndrome.size()
+                  << ") does not match the number of detectors in the decoder ("
+                  << self.num_detectors << ").";
+              throw std::invalid_argument(msg.str());
+            }
+
+            std::vector<uint64_t> detections;
+            auto syndrome_unchecked = syndrome.unchecked<1>();
+            for (size_t i = 0; i < (size_t)syndrome_unchecked.size(); ++i) {
+              if (syndrome_unchecked(i)) {
+                detections.push_back(i);
+              }
+            }
+            self.decode_to_errors(detections);
+            return self.predicted_errors_buffer;
+          },
+          py::arg("syndrome"),
+          py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>(),
+          R"pbdoc(
             Decodes a single shot to a list of error indices.
 
             Parameters
             ----------
-            detections : list[int]
-                A list of indices of the detectors that have fired.
+            syndrome : np.ndarray
+                A 1D NumPy array of booleans representing the detector outcomes for a single shot.
+                The length of the array should match the number of detectors in the DEM.
 
             Returns
             -------
             list[int]
                 A list of predicted error indices.
-           )pbdoc")
+          )pbdoc")
       .def(
           "get_observables_from_errors",
           [](SimplexDecoder& self, const std::vector<size_t>& predicted_errors) {

--- a/src/tesseract.pybind.h
+++ b/src/tesseract.pybind.h
@@ -20,6 +20,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <sstream>
 
 #include "stim_utils.pybind.h"
 #include "tesseract.h"
@@ -170,33 +171,75 @@ void add_tesseract_module(py::module& root) {
         config : TesseractConfig
             The configuration object for the decoder.
       )pbdoc")
-      .def("decode_to_errors",
-           py::overload_cast<const std::vector<uint64_t>&>(&TesseractDecoder::decode_to_errors),
-           py::arg("detections"),
-           py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>(), R"pbdoc(
+      .def(
+          "decode_to_errors",
+          [](TesseractDecoder& self, const py::array_t<bool>& syndrome) {
+            if ((size_t)syndrome.size() != self.num_detectors) {
+              std::ostringstream msg;
+              msg << "Syndrome array size (" << syndrome.size()
+                  << ") does not match the number of detectors in the decoder ("
+                  << self.num_detectors << ").";
+              throw std::invalid_argument(msg.str());
+            }
+
+            std::vector<uint64_t> detections;
+            auto syndrome_unchecked = syndrome.unchecked<1>();
+            for (size_t i = 0; i < (size_t)syndrome_unchecked.size(); ++i) {
+              if (syndrome_unchecked(i)) {
+                detections.push_back(i);
+              }
+            }
+            self.decode_to_errors(detections);
+            return self.predicted_errors_buffer;
+          },
+          py::arg("syndrome"),
+          py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>(),
+          R"pbdoc(
             Decodes a single shot to a list of error indices.
 
             Parameters
             ----------
-            detections : list[int]
-                A list of indices of the detectors that have fired.
+            syndrome : np.ndarray
+                A 1D NumPy array of booleans representing the detector outcomes for a single shot.
+                The length of the array should match the number of detectors in the DEM.
 
             Returns
             -------
             list[int]
                 A list of predicted error indices.
-           )pbdoc")
-      .def("decode_to_errors",
-           py::overload_cast<const std::vector<uint64_t>&, size_t, size_t>(
-               &TesseractDecoder::decode_to_errors),
-           py::arg("detections"), py::arg("det_order"), py::arg("det_beam"),
-           py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>(), R"pbdoc(
+          )pbdoc")
+      .def(
+          "decode_to_errors",
+          [](TesseractDecoder& self, const py::array_t<bool>& syndrome, size_t det_order,
+             size_t det_beam) {
+            if ((size_t)syndrome.size() != self.num_detectors) {
+              std::ostringstream msg;
+              msg << "Syndrome array size (" << syndrome.size()
+                  << ") does not match the number of detectors in the decoder ("
+                  << self.num_detectors << ").";
+              throw std::invalid_argument(msg.str());
+            }
+
+            std::vector<uint64_t> detections;
+            auto syndrome_unchecked = syndrome.unchecked<1>();
+            for (size_t i = 0; i < (size_t)syndrome_unchecked.size(); ++i) {
+              if (syndrome_unchecked(i)) {
+                detections.push_back(i);
+              }
+            }
+            self.decode_to_errors(detections, det_order, det_beam);
+            return self.predicted_errors_buffer;
+          },
+          py::arg("syndrome"), py::arg("det_order"), py::arg("det_beam"),
+          py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>(),
+          R"pbdoc(
             Decodes a single shot using a specific detector ordering and beam size.
 
             Parameters
             ----------
-            detections : list[int]
-                A list of indices of the detectors that have fired.
+            syndrome : np.ndarray
+                A 1D NumPy array of booleans representing the detector outcomes for a single shot.
+                The length of the array should match the number of detectors in the DEM.
             det_order : int
                 The index of the detector ordering to use.
             det_beam : int
@@ -206,7 +249,7 @@ void add_tesseract_module(py::module& root) {
             -------
             list[int]
                 A list of predicted error indices.
-           )pbdoc")
+          )pbdoc")
       .def(
           "get_observables_from_errors",
           [](TesseractDecoder& self, const std::vector<size_t>& predicted_errors) {


### PR DESCRIPTION
## Summary
- Expand `decode_to_errors` bindings to accept syndrome bitstrings and return predicted error indices
- Update docs and examples to describe bitstring-based usage
- Adjust unit tests for new API

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=.. pytest` *(fails: ModuleNotFoundError: No module named 'py.tesseract_test'; 'py' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c26b84048320ab7aaf92d1350ddc