### PR TITLE
Add explicit DetIndex branch for detector ordering

### DIFF
--- a/src/py/utils_test.py
+++ b/src/py/utils_test.py
@@ -50,10 +50,23 @@ def test_build_det_orders():
     ) == [[0, 1]]
 
 
-def test_build_det_orders_no_bfs():
+def test_build_det_orders_coordinate():
     assert tesseract_decoder.utils.build_det_orders(
-        _DETECTOR_ERROR_MODEL, num_det_orders=1, det_order_bfs=False, seed=0
+        _DETECTOR_ERROR_MODEL,
+        num_det_orders=1,
+        method=tesseract_decoder.utils.DetOrder.DetCoordinate,
+        seed=0,
     ) == [[0, 1]]
+
+
+def test_build_det_orders_index():
+    res = tesseract_decoder.utils.build_det_orders(
+        _DETECTOR_ERROR_MODEL,
+        num_det_orders=1,
+        method=tesseract_decoder.utils.DetOrder.DetIndex,
+        seed=0,
+    )
+    assert res == [[0, 1]] or res == [[1, 0]]
 
 
 def test_get_errors_from_dem():

--- a/src/tesseract.pybind.h
+++ b/src/tesseract.pybind.h
@@ -41,7 +41,7 @@ TesseractConfig tesseract_config_maker_no_dem(
     double det_penalty = 0.0, bool create_visualization = false) {
   stim::DetectorErrorModel empty_dem;
   if (det_orders.empty()) {
-    det_orders = build_det_orders(empty_dem, 20, /*det_order_bfs=*/true, 2384753);
+    det_orders = build_det_orders(empty_dem, 20, DetOrder::DetBFS, 2384753);
   }
   return TesseractConfig({empty_dem, det_beam, beam_climbing, no_revisit_dets,
                           at_most_two_errors_per_detector, verbose, merge_errors, pqlimit,
@@ -57,7 +57,7 @@ TesseractConfig tesseract_config_maker(
     double det_penalty = 0.0, bool create_visualization = false) {
   stim::DetectorErrorModel input_dem = parse_py_object<stim::DetectorErrorModel>(dem);
   if (det_orders.empty()) {
-    det_orders = build_det_orders(input_dem, 20, true, 2384753);
+    det_orders = build_det_orders(input_dem, 20, DetOrder::DetBFS, 2384753);
   }
   return TesseractConfig({input_dem, det_beam, beam_climbing, no_revisit_dets,
                           at_most_two_errors_per_detector, verbose, merge_errors, pqlimit,

--- a/src/utils.h
+++ b/src/utils.h
@@ -34,8 +34,11 @@ std::vector<std::vector<double>> get_detector_coords(const stim::DetectorErrorMo
 // in the model activates them both.
 std::vector<std::vector<size_t>> build_detector_graph(const stim::DetectorErrorModel& dem);
 
+enum class DetOrder { DetBFS, DetIndex, DetCoordinate };
+
 std::vector<std::vector<size_t>> build_det_orders(const stim::DetectorErrorModel& dem,
-                                                  size_t num_det_orders, bool det_order_bfs = true,
+                                                  size_t num_det_orders,
+                                                  DetOrder method = DetOrder::DetBFS,
                                                   uint64_t seed = 0);
 
 const double INF = std::numeric_limits<double>::infinity();


### PR DESCRIPTION
## Summary
- handle DetOrder::DetIndex explicitly in `build_det_orders`

## Testing
- `cmake -S . -B build`
- `cmake --build build --target tesseract_decoder`


------
https://chatgpt.com/codex/tasks/task_e_68b1f9fb6418832097f5c83ee1d78bca